### PR TITLE
 replace usage of  getfuncargvalue with getfixturevalue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [feature] - migrate usage of getfuncargvalue to getfixturevalue. require at least pytest 3.0.0
+
 1.0.0
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def read(fname):
 
 requirements = [
     'psycopg2',
-    'pytest',
+    'pytest>=3.0.0',
     'port-for',
     'path.py>=4.2',
     'mirakuru'

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -20,7 +20,7 @@
 import re
 import subprocess
 
-from path import path
+from path import Path
 
 from mirakuru import TCPExecutor
 
@@ -60,7 +60,7 @@ class PostgreSQLExecutor(TCPExecutor):
         self.executable = executable
         self.user = user
         self.version = self.version()
-        self.datadir = path(datadir)
+        self.datadir = Path(datadir)
         self.unixsocketdir = unixsocketdir
         command = self.proc_start_command().format(
             executable=self.executable,

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -256,7 +256,7 @@ def postgresql(process_fixture_name, db='tests'):
         :rtype: psycopg2.connection
         :returns: postgresql client
         """
-        proc_fixture = request.getfuncargvalue(process_fixture_name)
+        proc_fixture = request.getfixturevalue(process_fixture_name)
 
         # _, config = try_import('psycopg2', request)
         pg_host = proc_fixture.host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Tests main conftest file."""
+import sys
+import warnings
+
+major, minor = sys.version_info[:2]
+
+if not (major >= 3 and minor >= 5):
+    warnings.simplefilter("error", category=DeprecationWarning)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -23,7 +23,7 @@ postgresql94 = factories.postgresql_proc(pg_ctl.format(ver='9.4'), port=None)
 ))
 def test_postgresql_proc(request, postgres):
     """Test different postgresql versions."""
-    postgresql_proc = request.getfuncargvalue(postgres)
+    postgresql_proc = request.getfixturevalue(postgres)
     assert postgresql_proc.running() is True
 
 


### PR DESCRIPTION
- make pytest 3.0.0 a minimum requirement

- throw an error in own tests on deprecation warning.