### PR TITLE
Fixing the default pg_ctl path creation

### DIFF
--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -189,7 +189,7 @@ def postgresql_proc(
             pg_bindir = subprocess.check_output(
                 ['pg_config', '--bindir'], universal_newlines=True
             ).strip()
-            postgresql_ctl = os.path.join(pg_bindir, 'executable')
+            postgresql_ctl = os.path.join(pg_bindir, 'pg_ctl')
 
         pg_host = host or config['host']
         pg_port = get_port(port) or get_port(config['port'])


### PR DESCRIPTION
Fix this : Command '/usr/lib/postgresql/9.4/bin/**executable** initdb -o "--auth=trust --username=postgres" -D /tmp/postgresqldata.6789' returned non-zero exit status 127

Problem introduced by PR #5 

Changes proposed.
