### PR TITLE
Disallow connecting to the database before it's dropped

### DIFF
--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -133,11 +133,14 @@ def drop_postgresql_database(user, host, port, db, version):
     conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     cur = conn.cursor()
     # We cannot drop the database while there are connections to it, so we
-    # terminate all connections first.
+    # terminate all connections first while not allowing new connections.
     if float(version) >= 9.2:
         pid_column = 'pid'
     else:
         pid_column = 'procpid'
+    cur.execute(
+        'UPDATE pg_database SET datallowconn=false WHERE datname = %s;',
+        (db,))
     cur.execute(
         'SELECT pg_terminate_backend(pg_stat_activity.{0})'
         'FROM pg_stat_activity WHERE pg_stat_activity.datname = %s;'.format(


### PR DESCRIPTION
Fixes #14.

This is exactly the solution proposed in #44. I don't know a nice way to test it: I would know if it helps only from running many CI builds of a complex project with session-scoped fixtures and other processes.