### PR TITLE
turn off logging_collector explicitly - closes #90

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [enhancement] explicitly turn off logging_collector
+
 1.3.0
 -------
 

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -32,9 +32,12 @@ class PostgreSQLExecutor(TCPExecutor):
     <http://www.postgresql.org/docs/9.1/static/app-pg-ctl.html>`_
     """
 
-    BASE_PROC_START_COMMAND = """{executable} start -D {datadir}
-    -o "-F -p {port} -c log_destination='stderr' -c %s='{unixsocketdir}'"
-    -l {logfile} {startparams}"""
+    BASE_PROC_START_COMMAND = ' '.join((
+        "{executable} start -D {datadir}",
+        "-o \"-F -p {port} -c log_destination='stderr'",
+        "-c logging_collector=off -c %s='{unixsocketdir}'\"",
+        "-l {logfile} {startparams}"
+    ))
 
     def __init__(self, executable, host, port,
                  datadir, unixsocketdir, logfile, startparams,


### PR DESCRIPTION
    On some systems it's turned on by default, capturing logs and preventing from detecting proper start message in logs