### PR TITLE
properly detect if executor running and clean after executor is being…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+unreleased
+-------
+
+- [bugfix] properly detect if executor running and clean after executor is being stopped
+
+    .. note::
+
+        Previously if a test failed, there was a possibility of the executor being removed when python was closing,
+        causing it to print ignored errors on already unloaded modules.
+
 1.3.3
 -------
 

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -97,13 +97,19 @@ class PostgreSQLExecutor(TCPExecutor):
         if not os.path.exists(self.datadir):
             return False
 
-        output = subprocess.check_output(
-            '{pg_ctl} status -D {datadir}'.format(
-                pg_ctl=self.executable,
-                datadir=self.datadir
-            ),
-            shell=True
-        ).decode('utf-8')
+        try:
+            output = subprocess.check_output(
+                '{pg_ctl} status -D {datadir}'.format(
+                    pg_ctl=self.executable,
+                    datadir=self.datadir
+                ),
+                shell=True
+            ).decode('utf-8')
+        except subprocess.CalledProcessError as e:
+            if b'pg_ctl: no server running' in e.output:
+                return False
+            raise
+
         return "pg_ctl: server is running" in output
 
     def stop(self):
@@ -116,3 +122,4 @@ class PostgreSQLExecutor(TCPExecutor):
                 unixsocketdir=self.unixsocketdir
             ),
             shell=True)
+        super(PostgreSQLExecutor, self).stop()


### PR DESCRIPTION
… stopped - closes #109

    Previously if a test failed, there was a possibility of the executor being removed when python was closing,
    causing it to print ignored errors on already unloaded modules.