### PR TITLE
Always start postgresql with LC_ALL, LC_TYPE and LANG set to C.UTF-8 …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 -------
 
+- [bugfix] Always start postgresql with LC_ALL, LC_TYPE and LANG set to C.UTF-8.
+  It makes postgresql start in english.
 - [feature] Drop support for python 2.7. From now on, only suuport python 3.5 and up.
 - [feature] Ability to configure database name through plugin options
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def read(fname):
 requirements = [
     'pytest>=3.0.0',
     'port-for',
-    'mirakuru'
+    'mirakuru>=2.0.0'
 ]
 
 test_requires = [

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -77,7 +77,18 @@ class PostgreSQLExecutor(TCPExecutor):
             startparams=startparams,
         )
         super().__init__(
-            command, host, port, shell=shell, timeout=timeout, sleep=sleep)
+            command,
+            host,
+            port,
+            shell=shell,
+            timeout=timeout,
+            sleep=sleep,
+            envvars={
+                'LC_ALL': 'C.UTF-8',
+                'LC_CTYPE': 'C.UTF-8',
+                'LANG': 'C.UTF-8',
+            }
+        )
 
     def proc_start_command(self):
         """Based on postgres version return proper start command."""


### PR DESCRIPTION
…- closes #16

    It makes postgresql start in english

Fixes #16 .