### PR TITLE
Use pytest's tmpdir_factory instead of custom logsdir option - closes…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,11 @@ CHANGELOG
 Unreleased
 -------
 
+- [feature] Drop support for python 2.7. From now on, only support python 3.5 and up.
+- [feature] Ability to configure database name through plugin options
+- [enhancement] Use tmpdir_factory. Drop `logsdir` parameter
 - [bugfix] Always start postgresql with LC_ALL, LC_TYPE and LANG set to C.UTF-8.
   It makes postgresql start in english.
-- [feature] Drop support for python 2.7. From now on, only suuport python 3.5 and up.
-- [feature] Ability to configure database name through plugin options
 
 1.4.1
 -------

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ You can also create additional postgresql client and process fixtures if you'd n
     from pytest_postgresql import factories
 
     postgresql_my_proc = factories.postgresql_proc(
-        port=None, logsdir='/tmp')
+        port=None, unixsocketdir='/var/run')
     postgresql_my = factories.postgresql('postgresql_my_proc')
 
 .. note::
@@ -120,11 +120,6 @@ You can pick which you prefer, but remember that these settings are handled in t
      - --postgresql-startparams
      - postgresql_startparams
      - -w
-   * - Log directory location
-     - logsdir
-     - --postgresql-logsdir
-     - postgresql_logsdir
-     - $TMPDIR
    * - Log filename's prefix
      - logsprefix
      - --postgresql-logsprefix

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -60,7 +60,9 @@ def wait_for_postgres(logfile, awaited_msg):
     :param str awaited_msg: awaited message
     """
     # wait until logfile is created
-    while not os.path.isfile(logfile):
+    # Cast to str. Since Python 3.6 it's possible to pass a A Pathlike object.
+    # Python 3.5 however still needs string
+    while not os.path.isfile(str(logfile)):
         time.sleep(1)
 
     # wait for expected message.

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -59,15 +59,16 @@ def wait_for_postgres(logfile, awaited_msg):
     :param str logfile: logfile path
     :param str awaited_msg: awaited message
     """
-    # wait until logfile is created
     # Cast to str. Since Python 3.6 it's possible to pass a A Pathlike object.
     # Python 3.5 however still needs string
-    while not os.path.isfile(str(logfile)):
+    logfile_path = str(logfile)
+    # wait until logfile is created
+    while not os.path.isfile(logfile_path):
         time.sleep(1)
 
     # wait for expected message.
     while 1:
-        with open(logfile, 'r') as content_file:
+        with open(logfile_path, 'r') as content_file:
             content = content_file.read()
             if awaited_msg in content:
                 break

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -38,7 +38,7 @@ def get_config(request):
     """Return a dictionary with config options."""
     config = {}
     options = [
-        'exec', 'host', 'port', 'user', 'options', 'startparams', 'logsdir',
+        'exec', 'host', 'port', 'user', 'options', 'startparams',
         'logsprefix', 'unixsocketdir', 'dbname'
     ]
     for option in options:
@@ -155,7 +155,7 @@ def drop_postgresql_database(user, host, port, db_name, version):
 
 def postgresql_proc(
         executable=None, host=None, port=-1, user=None, options='',
-        startparams=None, unixsocketdir=None, logsdir=None, logs_prefix='',
+        startparams=None, unixsocketdir=None, logs_prefix='',
 ):
     """
     Postgresql process factory.
@@ -172,13 +172,12 @@ def postgresql_proc(
     :param str user: postgresql username
     :param str startparams: postgresql starting parameters
     :param str unixsocketdir: directory to create postgresql's unixsockets
-    :param str logsdir: location for logs
     :param str logs_prefix: prefix for log filename
     :rtype: func
     :returns: function which makes a postgresql process
     """
     @pytest.fixture(scope='session')
-    def postgresql_proc_fixture(request):
+    def postgresql_proc_fixture(request, tmpdir_factory):
         """
         Process fixture for PostgreSQL.
 
@@ -204,12 +203,12 @@ def postgresql_proc(
         pg_options = options or config['options']
         pg_unixsocketdir = unixsocketdir or config['unixsocketdir']
         pg_startparams = startparams or config['startparams']
-        pg_logsdir = logsdir or config['logsdir']
-        logfile_path = os.path.join(
-            pg_logsdir, '{prefix}postgresql.{port}.log'.format(
+        logfile_path = tmpdir_factory.mktemp("data").join(
+            '{prefix}postgresql.{port}.log'.format(
                 prefix=logs_prefix,
                 port=pg_port
-            ))
+            )
+        )
 
         init_postgresql_directory(
             postgresql_ctl, pg_user, datadir

--- a/src/pytest_postgresql/plugin.py
+++ b/src/pytest_postgresql/plugin.py
@@ -28,7 +28,6 @@ _help_port = 'Port at which PostgreSQL will accept connections'
 _help_user = "PostgreSQL username"
 _help_options = "PostgreSQL connection options"
 _help_startparams = "Starting parameters for the PostgreSQL"
-_help_logsdir = "Logs directory location"
 _help_logsprefix = "Prefix for the log files"
 _help_unixsocketdir = "Location of the socket directory"
 _help_dbname = "Default database name"
@@ -70,12 +69,6 @@ def pytest_addoption(parser):
         name='postgresql_startparams',
         help=_help_startparams,
         default='-w'
-    )
-
-    parser.addini(
-        name='postgresql_logsdir',
-        help=_help_logsdir,
-        default=gettempdir()
     )
 
     parser.addini(
@@ -137,13 +130,6 @@ def pytest_addoption(parser):
         action='store',
         dest='postgresql_startparams',
         help=_help_startparams
-    )
-
-    parser.addoption(
-        '--postgresql-logsdir',
-        action='store',
-        dest='postgresql_logsdir',
-        help=_help_logsdir
     )
 
     parser.addoption(


### PR DESCRIPTION
… #84

Fixes #84 
