### PR TITLE
Correct default value of postgresql_port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ You can pick which you prefer, but remember that these settings are handled in t
      - port
      - --postgresql-port
      - postgresql_port
-     - yes (5436)
+     - yes (5432)
      - random
    * - postgresql user
      - user


### PR DESCRIPTION
The default of 5432 is supplied from https://github.com/ClearcodeHQ/pytest-postgresql/blob/bfb4ba60465335a93d76fce69e528a8a1a75e5f6/src/pytest_postgresql/factories.py#L227