### PR TITLE
Set DB name for janitor

### DIFF
--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -76,7 +76,12 @@ class DatabaseJanitor:
     @contextmanager
     def cursor(self) -> cursor:
         """Return postgresql cursor."""
-        conn = psycopg2.connect(dbname='postgres', user=self.user, host=self.host, port=self.port)
+        conn = psycopg2.connect(
+            dbname='postgres',
+            user=self.user,
+            host=self.host,
+            port=self.port,
+        )
         conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
         cur = conn.cursor()
         try:

--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -76,7 +76,7 @@ class DatabaseJanitor:
     @contextmanager
     def cursor(self) -> cursor:
         """Return postgresql cursor."""
-        conn = psycopg2.connect(user=self.user, host=self.host, port=self.port)
+        conn = psycopg2.connect(dbname='postgres', user=self.user, host=self.host, port=self.port)
         conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
         cur = conn.cursor()
         try:

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1,4 +1,5 @@
 """Database Janitor tests."""
+from unittest.mock import patch
 import pytest
 from pkg_resources import parse_version
 
@@ -12,3 +13,16 @@ def test_version_cast(version):
     """Test that version is cast to Version object."""
     janitor = DatabaseJanitor(None, None, None, None, version)
     assert janitor.version == VERSION
+
+
+@patch('pytest_postgresql.janitor.psycopg2.connect')
+def test_cursor_selects_postgres_database(connect_mock):
+    """Test that the cursor requests the postgres database."""
+    janitor = DatabaseJanitor('user', 'host', '1234', 'database_name', 9.0)
+    with janitor.cursor():
+        connect_mock.assert_called_once_with(
+            dbname='postgres',
+            user='user',
+            host='host',
+            port='1234'
+        )


### PR DESCRIPTION
Fixes #279.

This appears to fix the problem I have locally making a database when there's no database that matches the username. I'm not sure of any broader consequences for how this cursor is used, however, so would welcome your advice.