### PR TITLE
Allow setting passwords

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,12 @@ You can pick which you prefer, but remember that these settings are handled in t
      - postgresql_user
      - yes
      - postgres
+   * - password
+     - password
+     - --postgresql-password
+     - postgresql_password
+     - yes
+     -
    * - Starting parameters
      - startparams
      - --postgresql-startparams

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -22,6 +22,7 @@ import os.path
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 
 from pkg_resources import parse_version
@@ -55,7 +56,7 @@ class PostgreSQLExecutor(TCPExecutor):
     def __init__(self, executable, host, port,
                  datadir, unixsocketdir, logfile, startparams,
                  shell=False, timeout=60, sleep=0.1, user='postgres',
-                 options=''):
+                 password='', options=''):
         """
         Initialize PostgreSQLExecutor executor.
 
@@ -72,10 +73,12 @@ class PostgreSQLExecutor(TCPExecutor):
         :param float sleep: how often to check for start/stop condition
         :param str user: [default] postgresql's username used to manage
             and access PostgreSQL
+        :param str password: optional password for the user
         """
         self._directory_initialised = False
         self.executable = executable
         self.user = user
+        self.password = password
         self.options = options
         self.datadir = datadir
         self.unixsocketdir = unixsocketdir
@@ -137,7 +140,17 @@ class PostgreSQLExecutor(TCPExecutor):
             '-o "--auth=trust --username=%s"' % self.user,
             '-D %s' % self.datadir,
         )
-        subprocess.check_output(' '.join(init_directory), shell=True)
+
+        if self.password:
+            with tempfile.NamedTemporaryFile() as password_file:
+                init_directory += (
+                    '--pwfile "%s"' % password_file.name
+                )
+                password_file.write(self.password)
+                subprocess.check_output(' '.join(init_directory), shell=True)
+        else:
+            subprocess.check_output(' '.join(init_directory), shell=True)
+
         self._directory_initialised = True
 
     def wait_for_postgres(self):

--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -34,7 +34,7 @@ class PostgreSQLUnsupported(Exception):
     """Exception raised when postgresql<9.0 would be detected."""
 
 
-# pylint:disable=too-many-instance-attributes
+# pylint:disable=too-many-arguments,too-many-instance-attributes
 class PostgreSQLExecutor(TCPExecutor):
     """
     PostgreSQL executor running on pg_ctl.

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -34,7 +34,7 @@ from pytest_postgresql.port import get_port
 class NoopExecutor:  # pylint: disable=too-few-public-methods
     """Nooperator executor."""
 
-    def __init__(self, host, port, user, options, password = None):
+    def __init__(self, host, port, user, options, password=None):
         """
         Initialize nooperator executor mock.
 
@@ -88,7 +88,7 @@ def get_config(request):
     return config
 
 
-def init_postgresql_database(user, host, port, db_name, password = None):
+def init_postgresql_database(user, host, port, db_name, password=None):
     """
     Create database in postgresql.
 
@@ -106,7 +106,7 @@ def init_postgresql_database(user, host, port, db_name, password = None):
     DatabaseJanitor(user, host, port, db_name, 0.0, password).init()
 
 
-def drop_postgresql_database(user, host, port, db_name, version, password = None):
+def drop_postgresql_database(user, host, port, db_name, version, password=None):
     """
     Drop databse in postgresql.
 

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -126,8 +126,8 @@ def drop_postgresql_database(user, host, port, db_name, version, password=None):
 
 
 def postgresql_proc(
-        executable=None, host=None, port=-1, user=None, password=None, options='',
-        startparams=None, unixsocketdir=None, logs_prefix='',
+        executable=None, host=None, port=-1, user=None, password=None,
+        options='', startparams=None, unixsocketdir=None, logs_prefix='',
 ):
     """
     Postgresql process factory.
@@ -202,7 +202,9 @@ def postgresql_proc(
     return postgresql_proc_fixture
 
 
-def postgresql_noproc(host=None, port=None, user=None, password=None, options=''):
+def postgresql_noproc(
+        host=None, port=None, user=None, password=None, options='',
+):
     """
     Postgresql noprocess factory.
 

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -34,19 +34,21 @@ from pytest_postgresql.port import get_port
 class NoopExecutor:  # pylint: disable=too-few-public-methods
     """Nooperator executor."""
 
-    def __init__(self, host, port, user, options):
+    def __init__(self, host, port, user, options, password = None):
         """
         Initialize nooperator executor mock.
 
         :param str host: Postgresql hostname
         :param str|int port: Postrgesql port
         :param str user: Postgresql username
+        :param str user: Postgresql password
         :param str options: Additional connection options
         """
         self.host = host
         self.port = int(port)
         self.user = user
         self.options = options
+        self.password = password
         self._version = None
 
     @property
@@ -58,6 +60,7 @@ class NoopExecutor:  # pylint: disable=too-few-public-methods
                     user=self.user,
                     host=self.host,
                     port=self.port,
+                    password=self.password,
                     options=self.options
             ) as connection:
                 version = str(connection.server_version)
@@ -74,7 +77,7 @@ def get_config(request):
     """Return a dictionary with config options."""
     config = {}
     options = [
-        'exec', 'host', 'port', 'user', 'options', 'startparams',
+        'exec', 'host', 'port', 'user', 'password', 'options', 'startparams',
         'logsprefix', 'unixsocketdir', 'dbname'
     ]
     for option in options:
@@ -85,7 +88,7 @@ def get_config(request):
     return config
 
 
-def init_postgresql_database(user, host, port, db_name):
+def init_postgresql_database(user, host, port, db_name, password = None):
     """
     Create database in postgresql.
 
@@ -93,16 +96,17 @@ def init_postgresql_database(user, host, port, db_name):
     :param str host: postgresql host
     :param str port: postgresql port
     :param str db_name: database name
+    :param str password: optional postgresql password
     """
     warn(
         'init_postgresql_database is deprecated, '
         'use DatabaseJanitor.init instead.',
         DeprecationWarning
     )
-    DatabaseJanitor(user, host, port, db_name, 0.0).init()
+    DatabaseJanitor(user, host, port, db_name, 0.0, password).init()
 
 
-def drop_postgresql_database(user, host, port, db_name, version):
+def drop_postgresql_database(user, host, port, db_name, version, password = None):
     """
     Drop databse in postgresql.
 
@@ -111,17 +115,18 @@ def drop_postgresql_database(user, host, port, db_name, version):
     :param str port: postgresql port
     :param str db_name: database name
     :param packaging.version.Version version: postgresql version number
+    :param str password: optional postgresql password
     """
     warn(
         'drop_postgresql_database is deprecated, '
         'use DatabaseJanitor.drop instead.',
         DeprecationWarning
     )
-    DatabaseJanitor(user, host, port, db_name, version).drop()
+    DatabaseJanitor(user, host, port, db_name, version, password).drop()
 
 
 def postgresql_proc(
-        executable=None, host=None, port=-1, user=None, options='',
+        executable=None, host=None, port=-1, user=None, password=None, options='',
         startparams=None, unixsocketdir=None, logs_prefix='',
 ):
     """
@@ -168,6 +173,7 @@ def postgresql_proc(
         datadir = os.path.join(
             gettempdir(), 'postgresqldata.{}'.format(pg_port))
         pg_user = user or config['user']
+        pg_password = password or config['password']
         pg_options = options or config['options']
         pg_unixsocketdir = unixsocketdir or config['unixsocketdir']
         pg_startparams = startparams or config['startparams']
@@ -187,6 +193,7 @@ def postgresql_proc(
             host=pg_host,
             port=pg_port,
             user=pg_user,
+            password=pg_password,
             options=pg_options,
             datadir=datadir,
             unixsocketdir=pg_unixsocketdir,
@@ -202,7 +209,7 @@ def postgresql_proc(
     return postgresql_proc_fixture
 
 
-def postgresql_noproc(host=None, port=None, user=None, options=''):
+def postgresql_noproc(host=None, port=None, user=None, password=None, options=''):
     """
     Postgresql noprocess factory.
 
@@ -226,12 +233,14 @@ def postgresql_noproc(host=None, port=None, user=None, options=''):
         pg_host = host or config['host']
         pg_port = port or config['port'] or 5432
         pg_user = user or config['user']
+        pg_password = password or config['password']
         pg_options = options or config['options']
 
         noop_exec = NoopExecutor(
             host=pg_host,
             port=pg_port,
             user=pg_user,
+            password=pg_password,
             options=pg_options,
         )
 
@@ -271,6 +280,7 @@ def postgresql(process_fixture_name, db_name=None):
         pg_host = proc_fixture.host
         pg_port = proc_fixture.port
         pg_user = proc_fixture.user
+        pg_password = proc_fixture.password
         pg_options = proc_fixture.options
         pg_db = db_name or config['dbname']
 
@@ -280,6 +290,7 @@ def postgresql(process_fixture_name, db_name=None):
             connection = psycopg2.connect(
                 dbname=pg_db,
                 user=pg_user,
+                password=pg_password,
                 host=pg_host,
                 port=pg_port,
                 options=pg_options

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -167,16 +167,9 @@ def postgresql_proc(
                 ['pg_config', '--bindir'], universal_newlines=True
             ).strip()
             postgresql_ctl = os.path.join(pg_bindir, 'pg_ctl')
-
-        pg_host = host or config['host']
         pg_port = get_port(port) or get_port(config['port'])
         datadir = os.path.join(
             gettempdir(), 'postgresqldata.{}'.format(pg_port))
-        pg_user = user or config['user']
-        pg_password = password or config['password']
-        pg_options = options or config['options']
-        pg_unixsocketdir = unixsocketdir or config['unixsocketdir']
-        pg_startparams = startparams or config['startparams']
         logfile_path = tmpdir_factory.mktemp("data").join(
             '{prefix}postgresql.{port}.log'.format(
                 prefix=logs_prefix,
@@ -190,15 +183,15 @@ def postgresql_proc(
 
         postgresql_executor = PostgreSQLExecutor(
             executable=postgresql_ctl,
-            host=pg_host,
+            host=host or config['host'],
             port=pg_port,
-            user=pg_user,
-            password=pg_password,
-            options=pg_options,
+            user=user or config['user'],
+            password=password or config['password'],
+            options=options or config['options'],
             datadir=datadir,
-            unixsocketdir=pg_unixsocketdir,
+            unixsocketdir=unixsocketdir or config['unixsocketdir'],
             logfile=logfile_path,
-            startparams=pg_startparams,
+            startparams=startparams or config['startparams'],
         )
         # start server
         with postgresql_executor:

--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -41,6 +41,7 @@ class DatabaseJanitor:
         :param version: postgresql version number
         """
         self.user = user
+        self.password = None
         self.host = host
         self.port = port
         self.db_name = db_name
@@ -48,6 +49,14 @@ class DatabaseJanitor:
             self.version = parse_version(str(version))
         else:
             self.version = version
+
+    def set_password(self, password) -> None:
+        """
+        Set a password for the database user.
+
+        :param password: postgresql password
+        """
+        self.password = password
 
     def init(self) -> None:
         """Create database in postgresql."""
@@ -79,6 +88,7 @@ class DatabaseJanitor:
         conn = psycopg2.connect(
             dbname='postgres',
             user=self.user,
+            password=self.password,
             host=self.host,
             port=self.port,
         )

--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -29,7 +29,8 @@ class DatabaseJanitor:
             host: str,
             port: str,
             db_name: str,
-            version: Union[str, float, Version]
+            version: Union[str, float, Version],
+            password: str = None
     ) -> None:
         """
         Initialize janitor.
@@ -39,9 +40,10 @@ class DatabaseJanitor:
         :param port: postgresql port
         :param db_name: database name
         :param version: postgresql version number
+        :param password: optional postgresql password
         """
         self.user = user
-        self.password = None
+        self.password = password
         self.host = host
         self.port = port
         self.db_name = db_name
@@ -49,14 +51,6 @@ class DatabaseJanitor:
             self.version = parse_version(str(version))
         else:
             self.version = version
-
-    def set_password(self, password) -> None:
-        """
-        Set a password for the database user.
-
-        :param password: postgresql password
-        """
-        self.password = password
 
     def init(self) -> None:
         """Create database in postgresql."""

--- a/src/pytest_postgresql/plugin.py
+++ b/src/pytest_postgresql/plugin.py
@@ -26,6 +26,7 @@ _help_executable = 'Path to PostgreSQL executable'
 _help_host = 'Host at which PostgreSQL will accept connections'
 _help_port = 'Port at which PostgreSQL will accept connections'
 _help_user = "PostgreSQL username"
+_help_password = "PostgreSQL password"
 _help_options = "PostgreSQL connection options"
 _help_startparams = "Starting parameters for the PostgreSQL"
 _help_logsprefix = "Prefix for the log files"
@@ -57,6 +58,12 @@ def pytest_addoption(parser):
         name='postgresql_user',
         help=_help_user,
         default='postgres'
+    )
+
+    parser.addini(
+        name='postgresql_password',
+        help=_help_password,
+        default=None
     )
 
     parser.addini(
@@ -116,6 +123,13 @@ def pytest_addoption(parser):
         action='store',
         dest='postgresql_user',
         help=_help_user
+    )
+
+    parser.addoption(
+        '--postgresql-password',
+        action='store',
+        dest='postgresql_password',
+        help=_help_password
     )
 
     parser.addoption(

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -23,6 +23,22 @@ def test_cursor_selects_postgres_database(connect_mock):
         connect_mock.assert_called_once_with(
             dbname='postgres',
             user='user',
+            password=None,
+            host='host',
+            port='1234'
+        )
+
+
+@patch('pytest_postgresql.janitor.psycopg2.connect')
+def test_cursor_connects_with_password(connect_mock):
+    """Test that the cursor requests the postgres database."""
+    janitor = DatabaseJanitor('user', 'host', '1234', 'database_name', 9.0)
+    janitor.set_password('some_password')
+    with janitor.cursor():
+        connect_mock.assert_called_once_with(
+            dbname='postgres',
+            user='user',
+            password='some_password',
             host='host',
             port='1234'
         )

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -32,7 +32,14 @@ def test_cursor_selects_postgres_database(connect_mock):
 @patch('pytest_postgresql.janitor.psycopg2.connect')
 def test_cursor_connects_with_password(connect_mock):
     """Test that the cursor requests the postgres database."""
-    janitor = DatabaseJanitor('user', 'host', '1234', 'database_name', 9.0, 'some_password')
+    janitor = DatabaseJanitor(
+        'user',
+        'host',
+        '1234',
+        'database_name',
+        9.0,
+        'some_password'
+    )
     with janitor.cursor():
         connect_mock.assert_called_once_with(
             dbname='postgres',

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -32,8 +32,7 @@ def test_cursor_selects_postgres_database(connect_mock):
 @patch('pytest_postgresql.janitor.psycopg2.connect')
 def test_cursor_connects_with_password(connect_mock):
     """Test that the cursor requests the postgres database."""
-    janitor = DatabaseJanitor('user', 'host', '1234', 'database_name', 9.0)
-    janitor.set_password('some_password')
+    janitor = DatabaseJanitor('user', 'host', '1234', 'database_name', 9.0, 'some_password')
     with janitor.cursor():
         connect_mock.assert_called_once_with(
             dbname='postgres',


### PR DESCRIPTION
Fixes #260. 

* Allow setting a password when using the janitor. (493cf29)

    I've made this a separate method as I think it's probably useful to a minority of users, and I don't want to break the existing interface for the constructor.
    
    It's tempting to use keyword args for the constructor, but that would also be a disruptive change.

* Allow setting an optional password in the constructor. (5a3bde9)

    This avoids the need for an ugly setter just for this field.

* Fold long line to fix lint. (722532e)


* Allow passing a password in all of the places you can pass the other connection details. (8372fb013f8323aa30b72854d4edc42b7c53f987)

    initdb doesn't accept a password on the command line, so I'm using a temporary file that's deleted immediately after use.

I've adjusted this to allow passing a password in the factories. Some of the tests won't run cleanly for me locally, so I'm having a little trouble adding more meaningful tests. Suggestions welcome.

I believe initdb will accept a password while also using `--auth=trust`, but I don't have a good way to run that locally at present.