### PR TITLE
Use chain.from_iterable in port.py

### DIFF
--- a/src/pytest_postgresql/port.py
+++ b/src/pytest_postgresql/port.py
@@ -72,7 +72,7 @@ def get_port(ports):
             ports = [ports]
         ranges = port_for.utils.ranges_to_set(filter_by_type(ports, tuple))
         nums = set(filter_by_type(ports, int))
-        sets = set(chain(*filter_by_type(ports, (set, frozenset))))
+        sets = set(chain.from_iterable(filter_by_type(ports, (set, frozenset))))
         ports_set = ports_set.union(ranges, sets, nums)
     except ValueError:
         raise InvalidPortsDefinition


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.