### PR TITLE
Fix password option to postgresql_proc

### DIFF
--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -144,7 +144,7 @@ class PostgreSQLExecutor(TCPExecutor):
         if self.password:
             with tempfile.NamedTemporaryFile() as password_file:
                 init_directory += (
-                    '--pwfile "%s"' % password_file.name
+                    '--pwfile "%s"' % password_file.name,
                 )
                 password_file.write(self.password)
                 subprocess.check_output(' '.join(init_directory), shell=True)


### PR DESCRIPTION
Without this comma, it tries to add a string to a tuple, which doesn't
work. This makes it add a tuple to a tuple, which does work.

Fixes #[ISSUE_NUMBER_HERE].

Changes proposed.