### PR TITLE
Fix password option

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,8 +1,10 @@
 """Test various executor behaviours."""
+import psycopg2
 import pytest
 from pkg_resources import parse_version
 
 from pytest_postgresql.executor import PostgreSQLExecutor, PostgreSQLUnsupported
+from pytest_postgresql.factories import postgresql_proc
 from pytest_postgresql.factories import get_config
 from pytest_postgresql.port import get_port
 
@@ -32,3 +34,29 @@ def test_unsupported_version(request):
 
     with pytest.raises(PostgreSQLUnsupported):
         executor.start()
+
+
+postgres_with_password = postgresql_proc(password='hunter2')
+
+
+def test_proc_with_password(
+        postgres_with_password):  # pylint: disable=redefined-outer-name
+    """Check that password option to postgresql_proc factory is honored."""
+    assert postgres_with_password.running() is True
+
+    # no assertion necessary here; we just want to make sure it connects with
+    # the password
+    psycopg2.connect(
+        dbname=postgres_with_password.user,
+        user=postgres_with_password.user,
+        password=postgres_with_password.password,
+        host=postgres_with_password.host,
+        port=postgres_with_password.port)
+
+    with pytest.raises(psycopg2.OperationalError):
+        psycopg2.connect(
+            dbname=postgres_with_password.user,
+            user=postgres_with_password.user,
+            password='bogus',
+            host=postgres_with_password.host,
+            port=postgres_with_password.port)


### PR DESCRIPTION
This contains a number of fixes for the password option to
postgresql_proc:

* Use password auth if it's specified, so that the password is
  actually honored.
* Move --pwfile into the options list so that it's passed through to
  `initdb`; otherwise it causes an error as `pg_ctl` doesn't expect a
  --pwfile option.
* Don't use a shell to run initdb.
* Use lists instead of tuples to avoid tuple copying on append.
* Flush the password file so that it actually hits disk.
* Add unit test to cover the password option.

Fixes #[ISSUE_NUMBER_HERE].

Changes proposed.