### PR TITLE
Add hook to centralize schema loads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,18 @@ Sample test
         postgresql.commit()
         cur.close()
 
+If you want the database fixture to be automatically populated with your schema:
+
+.. code-block:: python
+
+    postgresql_my_with_schema = factories.postgresql('postgresql_my_proc', load=['schemafile.sql', 'otherschema.sql'])
+
+.. note::
+
+    The database will still be dropped each time.
+
+
+
 Connecting to already existing postgresql database
 --------------------------------------------------
 
@@ -183,6 +195,12 @@ You can pick which you prefer, but remember that these settings are handled in t
      - postgresql_dbname
      - -
      - test
+   * - Default Schema
+     - load
+     - --postgresql-load
+     - postgresql_load
+     -
+     -
    * - PostgreSQL connection options
      - options
      - --postgresql-options

--- a/src/pytest_postgresql/plugin.py
+++ b/src/pytest_postgresql/plugin.py
@@ -32,6 +32,7 @@ _help_startparams = "Starting parameters for the PostgreSQL"
 _help_logsprefix = "Prefix for the log files"
 _help_unixsocketdir = "Location of the socket directory"
 _help_dbname = "Default database name"
+_help_load = "Load this SQL file by default, may be set multiple times"
 
 
 def pytest_addoption(parser):
@@ -94,6 +95,13 @@ def pytest_addoption(parser):
         name='postgresql_dbname',
         help=_help_dbname,
         default='tests'
+    )
+
+    parser.addini(
+        name='postgresql_load',
+        type='pathlist',
+        help=_help_load,
+        default=None
     )
 
     parser.addoption(
@@ -165,6 +173,13 @@ def pytest_addoption(parser):
         action='store',
         dest='postgresql_dbname',
         help=_help_dbname
+    )
+
+    parser.addoption(
+        '--postgresql-load',
+        action='append',
+        dest='postgresql_load',
+        help=_help_load
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 """Tests main conftest file."""
+import os
 from pytest_postgresql import factories
 
 
 PG_CTL = '/usr/lib/postgresql/{ver}/bin/pg_ctl'
+TEST_SQL_DIR = os.path.dirname(os.path.abspath(__file__)) + '/test_sql/'
 
 # pylint:disable=invalid-name
 postgresql92 = factories.postgresql_proc(PG_CTL.format(ver='9.2'), port=None)
@@ -15,6 +17,11 @@ postgresql11 = factories.postgresql_proc(PG_CTL.format(ver='11'), port=None)
 
 postgresql_proc2 = factories.postgresql_proc(port=9876)
 postgresql2 = factories.postgresql('postgresql_proc2', db_name='test-db')
+postgresql_load_1 = factories.postgresql('postgresql_proc2', db_name='test-db',
+                                         load=[TEST_SQL_DIR + 'test.sql', ])
+postgresql_load_2 = factories.postgresql('postgresql_proc2', db_name='test-db',
+                                         load=[TEST_SQL_DIR + 'test.sql',
+                                               TEST_SQL_DIR + 'test2.sql'])
 
 postgresql_rand_proc = factories.postgresql_proc(port=None)
 postgresql_rand = factories.postgresql('postgresql_rand_proc')

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -4,7 +4,8 @@ import psycopg2
 import pytest
 
 
-QUERY = "CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);"
+MAKE_Q = "CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);"
+SELECT_Q = "SELECT * FROM test;"
 
 
 @pytest.mark.skipif(
@@ -27,7 +28,7 @@ def test_postgresql_proc(request, postgres):
 def test_main_postgres(postgresql):
     """Check main postgresql fixture."""
     cur = postgresql.cursor()
-    cur.execute(QUERY)
+    cur.execute(MAKE_Q)
     postgresql.commit()
     cur.close()
 
@@ -35,13 +36,31 @@ def test_main_postgres(postgresql):
 def test_two_postgreses(postgresql, postgresql2):
     """Check two postgresql fixtures on one test."""
     cur = postgresql.cursor()
-    cur.execute(QUERY)
+    cur.execute(MAKE_Q)
     postgresql.commit()
     cur.close()
 
     cur = postgresql2.cursor()
-    cur.execute(QUERY)
+    cur.execute(MAKE_Q)
     postgresql2.commit()
+    cur.close()
+
+
+def test_postgres_load_one_file(postgresql_load_1):
+    """Check postgresql fixture can load one file."""
+    cur = postgresql_load_1.cursor()
+    cur.execute(SELECT_Q)
+    results = cur.fetchall()
+    assert len(results) == 1
+    cur.close()
+
+
+def test_postgres_load_two_files(postgresql_load_2):
+    """Check postgresql fixture can load two files."""
+    cur = postgresql_load_2.cursor()
+    cur.execute(SELECT_Q)
+    results = cur.fetchall()
+    assert len(results) == 2
     cur.close()
 
 

--- a/tests/test_sql/test.sql
+++ b/tests/test_sql/test.sql
@@ -1,0 +1,2 @@
+CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);
+INSERT INTO test VALUES(1, 2, 'c');

--- a/tests/test_sql/test2.sql
+++ b/tests/test_sql/test2.sql
@@ -1,0 +1,1 @@
+INSERT INTO test VALUES(2, 1, 'z');


### PR DESCRIPTION
Fixes https://github.com/ClearcodeHQ/pytest-postgresql/issues/316

When testing code interaction with the database, it can be cumbersome to create the schema each time.  This permits setting database definition at the fixture level so tests can assume the database has the relevant tables defined.