### PR TITLE
Pass locale environment to initdb and pg_ctl

### DIFF
--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -138,6 +138,7 @@ class PostgreSQLExecutor(TCPExecutor):
         self.clean_directory()
         init_directory = [self.executable, 'initdb', '--pgdata', self.datadir]
         options = ['--username=%s' % self.user]
+        env = self._popen_kwargs['env']
 
         if self.password:
             with tempfile.NamedTemporaryFile() as password_file:
@@ -150,11 +151,11 @@ class PostgreSQLExecutor(TCPExecutor):
                 password_file.write(password)
                 password_file.flush()
                 init_directory += ['-o', ' '.join(options)]
-                subprocess.check_output(init_directory)
+                subprocess.check_output(init_directory, env=env)
         else:
             options += ['--auth=trust']
             init_directory += ['-o', ' '.join(options)]
-            subprocess.check_output(init_directory)
+            subprocess.check_output(init_directory, env=env)
 
         self._directory_initialised = True
 
@@ -202,6 +203,7 @@ class PostgreSQLExecutor(TCPExecutor):
                     pg_ctl=self.executable,
                     datadir=self.datadir
                 ),
+                env=self._popen_kwargs['env'],
                 shell=True
             ).decode('utf-8')
         except subprocess.CalledProcessError as ex:


### PR DESCRIPTION
Fixes #315.

We pass the environment dict containing locale settings to calls of 'initdb' and 'pg_ctl'. This is so as to avoid [initdb to pick the locale setting of its execution environment][1] which, when not an English one, will then make the checks in PostgreSQLExecutor.running() (where the message "pg_ctl: server is running" is expected) fail.



[1]: https://www.postgresql.org/docs/current/locale.html
