### PR TITLE
Issue #339

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ jobs:
       - pip3 install virtualenv
       - virtualenv venv -p python3
       - source venv/bin/activate
+      addons:
+        apt:
+          packages:
+            - language-pack-de
       script:
       - py.test -n 0
     - stage: deploy

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -44,9 +44,14 @@ def test_unsupported_version(request):
     reason="Mac Os has completely different path for the executable"
            " than linux, and the default config."
 )
-def test_executor_init_with_password(request):
+@pytest.mark.parametrize('locale', (
+        "en_US.UTF-8",
+        "de_DE.UTF-8"
+))
+def test_executor_init_with_password(request, monkeypatch, locale):
     """Test whether the executor initializes properly."""
     config = get_config(request)
+    monkeypatch.setenv("LC_ALL", locale)
     executor = PostgreSQLExecutor(
         executable=config['exec'],
         host=config['host'],


### PR DESCRIPTION
Status checks for running postgres depend on pg_ctl status code, not on pg_ctl log language

Fixes #339.

Changes proposed.