### PR TITLE
Fixes #357 add option to alter isolation level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,9 @@ or use it as a context manager:
     DatabaseJanitor manages the state of the database, but you'll have to create
     connection to use in test code yourself.
 
+    You can optionally pass in a recognized postgresql ISOLATION_LEVEL for
+    additional control.
+
 Package resources
 -----------------
 

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -213,7 +213,8 @@ def postgresql_noproc(
 
 
 def postgresql(
-        process_fixture_name: str, db_name: str = None, load: List[str] = None
+        process_fixture_name: str, db_name: str = None, load: List[str] = None,
+        isolation_level: int = psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT,
 ) -> Callable[[FixtureRequest], connection]:
     """
     Return connection fixture factory for PostgreSQL.
@@ -221,6 +222,8 @@ def postgresql(
     :param process_fixture_name: name of the process fixture
     :param db_name: database name
     :param load: SQL to automatically load into our test database
+    :param isolation_level: optional postgresql isolation level
+                            defaults to ISOLATION_LEVEL_AUTOCOMMIT
     :returns: function which makes a connection to postgresql
     """
 
@@ -252,7 +255,7 @@ def postgresql(
 
         with DatabaseJanitor(
                 pg_user, pg_host, pg_port, pg_db, proc_fixture.version,
-                pg_password
+                pg_password, isolation_level
         ):
             db_connection: connection = psycopg2.connect(
                 dbname=pg_db,

--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -23,7 +23,8 @@ class DatabaseJanitor:
             port: str,
             db_name: str,
             version: Union[str, float, Version],
-            password: str = None
+            password: str = None,
+            isolation_level: int = psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT,
     ) -> None:
         """
         Initialize janitor.
@@ -34,12 +35,15 @@ class DatabaseJanitor:
         :param db_name: database name
         :param version: postgresql version number
         :param password: optional postgresql password
+        :param isolation_level: optional postgresql isolation level
+                                defaults to ISOLATION_LEVEL_AUTOCOMMIT
         """
         self.user = user
         self.password = password
         self.host = host
         self.port = port
         self.db_name = db_name
+        self.isolation_level = isolation_level
         if not isinstance(version, Version):
             self.version = parse_version(str(version))
         else:
@@ -79,7 +83,7 @@ class DatabaseJanitor:
             host=self.host,
             port=self.port,
         )
-        conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        conn.set_isolation_level(self.isolation_level)
         cur = conn.cursor()
         try:
             yield cur


### PR DESCRIPTION
Fixes #357 

This adds an optional argument to permit setting the postgresql isolation level for the fixtures.  The default of `ISOLATION_LEVEL_AUTOCOMMIT` is retained, but folks can now set another value if needed.