### PR TITLE
Remove reference to psycopg2 from default param value, function body

### DIFF
--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -225,6 +225,7 @@ def postgresql(
     :param db_name: database name
     :param load: SQL to automatically load into our test database
     :param isolation_level: optional postgresql isolation level
+                            defaults to ISOLATION_LEVEL_AUTOCOMMIT
     :returns: function which makes a connection to postgresql
     """
 

--- a/src/pytest_postgresql/factories.py
+++ b/src/pytest_postgresql/factories.py
@@ -21,7 +21,7 @@ import os.path
 import platform
 import subprocess
 from tempfile import gettempdir
-from typing import List, Callable, Union, Iterable
+from typing import List, Callable, Union, Iterable, Optional
 from warnings import warn
 
 import pytest
@@ -216,7 +216,7 @@ def postgresql_noproc(
 
 def postgresql(
         process_fixture_name: str, db_name: str = None, load: List[str] = None,
-        isolation_level: int = psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT,
+        isolation_level: Optional[int] = None,
 ) -> Callable[[FixtureRequest], connection]:
     """
     Return connection fixture factory for PostgreSQL.
@@ -225,7 +225,6 @@ def postgresql(
     :param db_name: database name
     :param load: SQL to automatically load into our test database
     :param isolation_level: optional postgresql isolation level
-                            defaults to ISOLATION_LEVEL_AUTOCOMMIT
     :returns: function which makes a connection to postgresql
     """
 

--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -24,7 +24,7 @@ class DatabaseJanitor:
             db_name: str,
             version: Union[str, float, Version],
             password: str = None,
-            isolation_level: int = psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT,
+            isolation_level: Optional[int] = None,
     ) -> None:
         """
         Initialize janitor.
@@ -43,7 +43,7 @@ class DatabaseJanitor:
         self.host = host
         self.port = port
         self.db_name = db_name
-        self.isolation_level = isolation_level
+        self.isolation_level = isolation_level or psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
         if not isinstance(version, Version):
             self.version = parse_version(str(version))
         else:


### PR DESCRIPTION
Fixes #369.

The default value for the isolation_level parameter introduced in #358 breaks pytest if psycopg2 is not installed. See #369 for detailed rationale. The proposed solution removes the reference to psycopg2 from factories.py and moves it into the method body in janitor.py. The original behavior is preserved.