### PR TITLE
Use ALTER DATABASE instead of update pg_database

### DIFF
--- a/src/pytest_postgresql/janitor.py
+++ b/src/pytest_postgresql/janitor.py
@@ -92,7 +92,7 @@ class DatabaseJanitor:
 
     @staticmethod
     def _dont_datallowconn(cur: cursor, dbname: str) -> None:
-        cur.execute("UPDATE pg_database SET datallowconn=false WHERE datname = %s;", (dbname,))
+        cur.execute(f'ALTER DATABASE "{dbname}" with allow_connections false;')
 
     @staticmethod
     def _terminate_connection(cur: cursor, dbname: str) -> None:


### PR DESCRIPTION
You can't update pg_database to change a database (you shouldn't be updating system tables at all, although you can do it for some of them).

Use ALTER DATABASE instead

Changes proposed.