### PR TITLE
fix: Typo in `TimeoutError` message

### DIFF
--- a/src/pytest_postgresql/retry.py
+++ b/src/pytest_postgresql/retry.py
@@ -31,5 +31,5 @@ def retry(
             return res
         except possible_exception as e:
             if time + timeout_diff < datetime.utcnow():
-                raise TimeoutError(f"Faile after {i} attempts") from e
+                raise TimeoutError(f"Failed after {i} attempts") from e
             sleep(1)


### PR DESCRIPTION
Hi! Thank you very much for the plugin!

When I recently ran my test suite without PG available, noticed an error message like this - `Faile after 61 attempts` which should be `Failed after 61 attempts`. This PR fixes a user-facing error message