### PR TITLE
VERSION_RE should support devel versions

### DIFF
--- a/src/pytest_postgresql/executor.py
+++ b/src/pytest_postgresql/executor.py
@@ -59,7 +59,7 @@ class PostgreSQLExecutor(TCPExecutor):
         "-l {logfile} {startparams}"
     )
 
-    VERSION_RE = re.compile(r".* (?P<version>\d+\.\d+)")
+    VERSION_RE = re.compile(r".* (?P<version>\d+(?:\.\d+)?)")
     MIN_SUPPORTED_VERSION = parse_version("10")
 
     def __init__(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -12,6 +12,7 @@ from pytest_postgresql.executor import PostgreSQLExecutor
         ("pg_ctl (PostgreSQL) 12.8", "12.8"),
         ("pg_ctl (PostgreSQL) 13.4", "13.4"),
         ("pg_ctl (PostgreSQL) 14.0", "14.0"),
+        ("pg_ctl (PostgreSQL) 16devel", "16"),
     ),
 )
 def test_versions(ctl_input: str, version: str) -> None:


### PR DESCRIPTION
When PostgreSQL is built from git, `pg_ctl --version` may report `pg_ctl (PostgreSQL) 16devel`, with no minor version number.

Changes proposed.