### PR TITLE
use codecov_token in tests

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -48,3 +48,4 @@ jobs:
         flags: macos
         env_vars: OS, PYTHON, POSTGRES
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,3 +87,4 @@ jobs:
         flags: linux
         env_vars: OS, PYTHON, POSTGRES
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/721.misc.rst
+++ b/newsfragments/721.misc.rst
@@ -1,0 +1,1 @@
+Pass codecov_token to codecov action to upload coverage.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number