### PR TITLE
Use a TypedDict for plugin options config - closes #706

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         postgres-version: [11, 12, 13, 14]
     env:
       OS: ubuntu-latest

--- a/newsfragments/706.break.rst
+++ b/newsfragments/706.break.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.7

--- a/newsfragments/706.misc.rst
+++ b/newsfragments/706.misc.rst
@@ -1,0 +1,1 @@
+Introduce Typed config dict

--- a/pytest_postgresql/config.py
+++ b/pytest_postgresql/config.py
@@ -1,25 +1,41 @@
+from typing import Optional, TypedDict
+
 from pytest import FixtureRequest
 
 
-def get_config(request: FixtureRequest) -> dict:
+class PostgresqlConfigDict(TypedDict):
+    exec: str
+    host: str
+    port: Optional[str | int]
+    user: str
+    password: Optional[str]
+    options: str
+    startparams: str
+    logsprefix: str
+    unixsocketdir: str
+    dbname: str
+    load: Optional[list[str]]
+    postgres_options: str
+
+
+def get_config(request: FixtureRequest) -> PostgresqlConfigDict:
     """Return a dictionary with config options."""
-    config = {}
-    options = [
-        "exec",
-        "host",
-        "port",
-        "user",
-        "password",
-        "options",
-        "startparams",
-        "logsprefix",
-        "unixsocketdir",
-        "dbname",
-        "load",
-        "postgres_options",
-    ]
-    for option in options:
-        option_name = "postgresql_" + option
-        conf = request.config.getoption(option_name) or request.config.getini(option_name)
-        config[option] = conf
-    return config
+
+    def get_postgresql_option(option: str):
+        name = "postgresql_" + option
+        return request.config.getoption(name) or request.config.getini(name)
+
+    return PostgresqlConfigDict(
+        exec=get_postgresql_option("exec"),
+        host=get_postgresql_option("host"),
+        port=get_postgresql_option("port"),
+        user=get_postgresql_option("user"),
+        password=get_postgresql_option("password"),
+        options=get_postgresql_option("options"),
+        startparams=get_postgresql_option("startparams"),
+        logsprefix=get_postgresql_option("logsprefix"),
+        unixsocketdir=get_postgresql_option("unixsocketdir"),
+        dbname=get_postgresql_option("dbname"),
+        load=get_postgresql_option("load"),
+        postgres_options=get_postgresql_option("postgres_options")
+    )

--- a/pytest_postgresql/config.py
+++ b/pytest_postgresql/config.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Any, List
 
 from pytest import FixtureRequest
 
@@ -6,22 +6,22 @@ from pytest import FixtureRequest
 class PostgresqlConfigDict(TypedDict):
     exec: str
     host: str
-    port: Optional[str | int]
+    port: Optional[str]
     user: str
-    password: Optional[str]
+    password: str
     options: str
     startparams: str
     logsprefix: str
     unixsocketdir: str
     dbname: str
-    load: Optional[list[str]]
+    load: List[str]
     postgres_options: str
 
 
 def get_config(request: FixtureRequest) -> PostgresqlConfigDict:
     """Return a dictionary with config options."""
 
-    def get_postgresql_option(option: str):
+    def get_postgresql_option(option: str) -> Any:
         name = "postgresql_" + option
         return request.config.getoption(name) or request.config.getini(name)
 
@@ -37,5 +37,5 @@ def get_config(request: FixtureRequest) -> PostgresqlConfigDict:
         unixsocketdir=get_postgresql_option("unixsocketdir"),
         dbname=get_postgresql_option("dbname"),
         load=get_postgresql_option("load"),
-        postgres_options=get_postgresql_option("postgres_options")
+        postgres_options=get_postgresql_option("postgres_options"),
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,7 +30,7 @@ classifiers =
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = >= 3.7
+python_requires = >= 3.8
 packages = pytest_postgresql
 install_requires =
     pytest>=6.2.0


### PR DESCRIPTION
Implemented `PostgresqlConfigDict(TypedDict)` which has the same keys as the previous `config` dict. The value types are what is expected from the `request.config` object after .ini or command line options are parsed, and in general fit the expected usages of `config["<some_option>"]`. Now, when a variable is set by getting a config value, there is a type hint for that variable. For example:
```python
config = get_config(request)
port = config["port"]
# type hint -- port: str | None
```