### PR TITLE
Dropped --postgresql-logsprefix - closes #748

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,12 +206,6 @@ You can pick which you prefer, but remember that these settings are handled in t
      - postgresql_postgres_options
      - -
      -
-   * - Log filename's prefix
-     - logsprefix
-     - --postgresql-logsprefix
-     - postgresql_logsprefix
-     - -
-     -
    * - Location for unixsockets
      - unixsocket
      - --postgresql-unixsocketdir

--- a/newsfragments/748.break.rst
+++ b/newsfragments/748.break.rst
@@ -1,0 +1,1 @@
+Dropped --postgresql-logsprefix/postgresql_logsprefix options. All fixture data is already distinguished by tmpdir itself.

--- a/pytest_postgresql/config.py
+++ b/pytest_postgresql/config.py
@@ -14,7 +14,6 @@ class PostgresqlConfigDict(TypedDict):
     password: str
     options: str
     startparams: str
-    logsprefix: str
     unixsocketdir: str
     dbname: str
     load: List[str]
@@ -36,7 +35,6 @@ def get_config(request: FixtureRequest) -> PostgresqlConfigDict:
         password=get_postgresql_option("password"),
         options=get_postgresql_option("options"),
         startparams=get_postgresql_option("startparams"),
-        logsprefix=get_postgresql_option("logsprefix"),
         unixsocketdir=get_postgresql_option("unixsocketdir"),
         dbname=get_postgresql_option("dbname"),
         load=get_postgresql_option("load"),

--- a/pytest_postgresql/plugin.py
+++ b/pytest_postgresql/plugin.py
@@ -29,7 +29,6 @@ _help_user = "PostgreSQL username"
 _help_password = "PostgreSQL password"
 _help_options = "PostgreSQL connection options"
 _help_startparams = "Starting parameters for the PostgreSQL"
-_help_logsprefix = "Prefix for the log files"
 _help_unixsocketdir = "Location of the socket directory"
 _help_dbname = "Default database name"
 _help_load = "Dotted-style or entrypoint-style path to callable or path to SQL File"
@@ -57,8 +56,6 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(name="postgresql_options", help=_help_options, default="")
 
     parser.addini(name="postgresql_startparams", help=_help_startparams, default="-w")
-
-    parser.addini(name="postgresql_logsprefix", help=_help_logsprefix, default="")
 
     parser.addini(name="postgresql_unixsocketdir", help=_help_unixsocketdir, default=gettempdir())
 
@@ -99,13 +96,6 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         dest="postgresql_startparams",
         help=_help_startparams,
-    )
-
-    parser.addoption(
-        "--postgresql-logsprefix",
-        action="store",
-        dest="postgresql_logsprefix",
-        help=_help_logsprefix,
     )
 
     parser.addoption(


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number