### PR TITLE
Better exception messages when we could not find proper executable - …

### DIFF
--- a/newsfragments/598.feature.rst
+++ b/newsfragments/598.feature.rst
@@ -1,0 +1,1 @@
+Re-rise FileNotFound errors with more meaningful messages.

--- a/pytest_postgresql/exceptions.py
+++ b/pytest_postgresql/exceptions.py
@@ -1,0 +1,9 @@
+"""pytest-postgresql's exceptions."""
+
+
+class ExecutableMissingException(FileNotFoundError):
+    """Exception risen when PgConfig was not found."""
+
+
+class PostgreSQLUnsupported(Exception):
+    """Exception raised when unsupported postgresql would be detected."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,7 +10,8 @@ from psycopg import Connection
 from pytest import FixtureRequest
 
 from pytest_postgresql.config import get_config
-from pytest_postgresql.executor import PostgreSQLExecutor, PostgreSQLUnsupported
+from pytest_postgresql.exceptions import PostgreSQLUnsupported
+from pytest_postgresql.executor import PostgreSQLExecutor
 from pytest_postgresql.factories import postgresql, postgresql_proc
 from pytest_postgresql.retry import retry
 


### PR DESCRIPTION
…closes #598

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number