### PR TITLE
README: fix section markup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -472,6 +472,7 @@ Fast, clean and no dangling transactions, that could be accidentally rolled back
 
 Same approach will work with noproces fixture, while connecting to already running postgresql instance whether
 it'll be on a docker machine or running remotely or locally.
+
 Release
 =======
 


### PR DESCRIPTION
Prevent Release header bleed into previous paragraph.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number