### PR TITLE
Fix README heading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ Client fixture then creates test database out of the template database each test
 
 
 The loading_function from example will receive , and have to commit that.
+
 Connecting to already existing postgresql database
 --------------------------------------------------
 

--- a/newsfragments/776.misc.rst
+++ b/newsfragments/776.misc.rst
@@ -1,0 +1,2 @@
+README: fix section markup
+


### PR DESCRIPTION
Found another broken heading 🤓

BTW, the line above is incomplete, but I couldn't figure out how to fix it. The word "populate" doesn't really appear within the repo?

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`
