### PR TITLE
Add optional scope and target_db parameter for postgres fixture

### DIFF
--- a/pytest_postgresql/factories/client.py
+++ b/pytest_postgresql/factories/client.py
@@ -33,6 +33,8 @@ def postgresql(
     dbname: Optional[str] = None,
     load: Optional[List[Union[Callable, str]]] = None,
     isolation_level: "Optional[psycopg.IsolationLevel]" = None,
+    scope="function",
+    target_dbname=None,
 ) -> Callable[[FixtureRequest], Iterator[Connection]]:
     """Return connection fixture factory for PostgreSQL.
 
@@ -45,7 +47,7 @@ def postgresql(
     :returns: function which makes a connection to postgresql
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope=scope)
     def postgresql_factory(request: FixtureRequest) -> Iterator[Connection]:
         """Fixture factory for PostgreSQL.
 
@@ -63,12 +65,13 @@ def postgresql(
         pg_options = proc_fixture.options
         pg_db = dbname or proc_fixture.dbname
         pg_load = load or []
+        target_db = target_dbname if target_dbname else pg_db
 
         with DatabaseJanitor(
-            pg_user, pg_host, pg_port, pg_db, proc_fixture.version, pg_password, isolation_level
+            pg_user, pg_host, pg_port, pg_db, proc_fixture.version, pg_password, isolation_level, target_dbname=target_db
         ) as janitor:
             db_connection: Connection = psycopg.connect(
-                dbname=pg_db,
+                dbname=target_db,
                 user=pg_user,
                 password=pg_password,
                 host=pg_host,

--- a/tests/test_postgresql_session_scope.py
+++ b/tests/test_postgresql_session_scope.py
@@ -1,0 +1,51 @@
+"""Template database tests."""
+import pytest
+from psycopg import Connection
+
+from pytest_postgresql.factories import postgresql, postgresql_proc
+from tests.loader import load_database
+
+postgresql_proc_with_template_for_session = postgresql_proc(
+    port=21987,
+    dbname="session_template",
+    load=[load_database],
+)
+
+postgresql_template_function = postgresql(
+    "postgresql_proc_with_template_for_session"
+)
+
+postgresql_template_session = postgresql(
+    "postgresql_proc_with_template_for_session",
+    target_dbname="some_unique_name",
+    scope="session",
+)
+
+# the two tests will use the same template DB, though one uses a session scoped fixture to setup
+# additional data to be shared between some tests. Because this db will live the entire 
+# session, it needs to have a special name that will not conflict with others. This allows
+# reusing the template database also in session scoped fixtures.
+
+@pytest.fixture(scope="session")
+def add_story(postgresql_template_session: Connection) -> Connection:
+    with postgresql_template_session.cursor() as cur:
+        cur.execute("INSERT INTO stories (name) VALUES ('Prince Caspian')")
+        postgresql_template_session.commit()
+
+
+@pytest.mark.parametrize("_", range(5))
+def test_function_scoped_client_fixture(postgresql_template_function: Connection, _: int) -> None:
+    """Check that the database structure gets recreated out of the template."""
+    with postgresql_template_function.cursor() as cur:
+        cur.execute("SELECT * FROM stories")
+        res = cur.fetchall()
+        assert len(res) == 4
+
+
+@pytest.mark.parametrize("_", range(5))
+def test_session_scoped_client_fixture(add_story: Connection, _: int) -> None:
+    """Check that the database structure gets recreated out of the template."""
+    with postgresql_template_session.cursor() as cur:
+        cur.execute("SELECT * FROM stories")
+        res = cur.fetchall()
+        assert len(res) == 5


### PR DESCRIPTION
These options allow to share the database instance between several tests that need common setup

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number