### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/newsfragments/865.misc.rst
+++ b/newsfragments/865.misc.rst
@@ -1,0 +1,12 @@
+Fix DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
+
+`datetime.datetime.utcnow` has been deprecated by Python and will soon be removed by Python 3.14 (see warning text below)
+
+The following warning used to pop up everytime someone with a recent version of Python (3.12+) uses this plugin
+
+.. code-block::
+
+    .venv/lib/python3.12/site-packages/pytest_postgresql/retry.py:22: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+        time: datetime = datetime.utcnow()
+
+    -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -42,7 +42,7 @@ def get_current_datetime() -> datetime.datetime:
     # To ensure the current datetime retrieval is adjusted with the latest
     # versions of Python while ensuring retro-compatibility with
     # Python 3.8, 3.9 and 3.10, we check what version of Python is
-    # being used before deciding
+    # being used before deciding how to operate
     if sys.version_info.major == 3 and sys.version_info.minor > 10:
         return datetime.datetime.now(datetime.UTC)
 

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -1,6 +1,6 @@
 """Small retry callable in case of specific error occurred."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from time import sleep
 from typing import Callable, Type, TypeVar
 
@@ -19,7 +19,7 @@ def retry(
     ... ::
         FATAL:  the database system is starting up
     """
-    time: datetime = datetime.utcnow()
+    time: datetime = datetime.now(UTC)
     timeout_diff: timedelta = timedelta(seconds=timeout)
     i = 0
     while True:

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -1,6 +1,6 @@
 """Small retry callable in case of specific error occurred."""
 
-from datetime import UTC, datetime, timedelta
+import datetime
 import sys
 from time import sleep
 from typing import Callable, Type, TypeVar
@@ -23,7 +23,7 @@ def retry(
         FATAL:  the database system is starting up
     """
     time: datetime = get_current_datetime()
-    timeout_diff: timedelta = timedelta(seconds=timeout)
+    timeout_diff: datetime.timedelta = datetime.timedelta(seconds=timeout)
     i = 0
     while True:
         i += 1
@@ -31,12 +31,12 @@ def retry(
             res = func()
             return res
         except possible_exception as e:
-            if time + timeout_diff < datetime.utcnow():
+            if time + timeout_diff < datetime.datetime.utcnow():
                 raise TimeoutError(f"Failed after {i} attempts") from e
             sleep(1)
 
 
-def get_current_datetime() -> datetime:
+def get_current_datetime() -> datetime.datetime:
     """Get the current datetime."""
 
     # To ensure the current datetime retrieval is adjusted with the latest
@@ -44,6 +44,6 @@ def get_current_datetime() -> datetime:
     # Python 3.8, 3.9 and 3.10, we check what version of Python is
     # being used before deciding
     if sys.version_info.major == 3 and sys.version_info.minor > 10:
-        return datetime.now(UTC)
+        return datetime.datetime.now(datetime.UTC)
 
-    return datetime.utcnow()
+    return datetime.datetime.utcnow()

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -1,6 +1,7 @@
 """Small retry callable in case of specific error occurred."""
 
 from datetime import UTC, datetime, timedelta
+import sys
 from time import sleep
 from typing import Callable, Type, TypeVar
 
@@ -21,7 +22,7 @@ def retry(
     ... ::
         FATAL:  the database system is starting up
     """
-    time: datetime = datetime.now(UTC)
+    time: datetime = get_current_datetime()
     timeout_diff: timedelta = timedelta(seconds=timeout)
     i = 0
     while True:
@@ -33,3 +34,16 @@ def retry(
             if time + timeout_diff < datetime.utcnow():
                 raise TimeoutError(f"Failed after {i} attempts") from e
             sleep(1)
+
+
+def get_current_datetime() -> datetime:
+    """Get the current datetime."""
+
+    # To ensure the current datetime retrieval is adjusted with the latest
+    # versions of Python while ensuring retro-compatibility with
+    # Python 3.8, 3.9 and 3.10, we check what version of Python is
+    # being used before deciding
+    if sys.version_info.major == 3 and sys.version_info.minor > 10:
+        return datetime.now(UTC)
+
+    return datetime.utcnow()

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -8,7 +8,9 @@ T = TypeVar("T")
 
 
 def retry(
-    func: Callable[[], T], timeout: int = 60, possible_exception: Type[Exception] = Exception
+    func: Callable[[], T],
+    timeout: int = 60,
+    possible_exception: Type[Exception] = Exception,
 ) -> T:
     """Attempt to retry the function for timeout time.
 

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -38,7 +38,6 @@ def retry(
 
 def get_current_datetime() -> datetime.datetime:
     """Get the current datetime."""
-
     # To ensure the current datetime retrieval is adjusted with the latest
     # versions of Python while ensuring retro-compatibility with
     # Python 3.8, 3.9 and 3.10, we check what version of Python is

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -22,7 +22,7 @@ def retry(
     ... ::
         FATAL:  the database system is starting up
     """
-    time: datetime = get_current_datetime()
+    time: datetime.datetime = get_current_datetime()
     timeout_diff: datetime.timedelta = datetime.timedelta(seconds=timeout)
     i = 0
     while True:

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -1,6 +1,6 @@
 """Small retry callable in case of specific error occurred."""
 
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from time import sleep
 from typing import Callable, Type, TypeVar
 


### PR DESCRIPTION
`datetime.datetime.utcnow` has been deprecated by Python and will soon be removed by Python 3.14 (see warning text below)

Besides, this warning pops up everytime someone with a recent version of Python (3.12+) uses this plugin, which makes the testing experience uncomfortable. I thus thought this contribution would be nice

```
.venv/lib/python3.12/site-packages/pytest_postgresql/retry.py:22: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    time: datetime = datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number