### PR TITLE
Deprecate load on client fixture - closes #850

### DIFF
--- a/newsfragments/850.deprecate.rst
+++ b/newsfragments/850.deprecate.rst
@@ -1,0 +1,4 @@
+Deprecated load parameter on a client fixture.
+Developers are encouraged to either use the load function/parameter
+for process fixture, or create an intermediate fixture placed between client
+and tests themselves to fill in the data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,13 +94,17 @@ showcontent = true
 name = "Bugfixes"
 showcontent = true
 
+[tool.towncrier.fragment.deprecate]
+name = "Deprecations"
+showcontent = true
+
 [tool.towncrier.fragment.break]
 name = "Breaking changes"
 showcontent = true
 
 [tool.towncrier.fragment.misc]
 name = "Miscellaneus"
-showcontent = true
+showcontent = false
 
 [tool.tbump.version]
 current = "5.1.0"

--- a/pytest_postgresql/factories/client.py
+++ b/pytest_postgresql/factories/client.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pytest-dbfixtures.  If not, see <http://www.gnu.org/licenses/>.
 """Fixture factory for postgresql client."""
+import warnings
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Union
 
@@ -64,6 +65,16 @@ def postgresql(
         pg_options = proc_fixture.options
         pg_db = dbname or proc_fixture.dbname
         pg_load = load or []
+        if pg_load:
+            warnings.warn(
+                message=(
+                    "Load is deprecated on a client fixture. "
+                    "You should either process fixture load parameter to pre-fill database, "
+                    "or add a fixture between client and a test, "
+                    "that will fill the database with the data."
+                ),
+                category=DeprecationWarning,
+            )
 
         with DatabaseJanitor(
             pg_user, pg_host, pg_port, pg_db, proc_fixture.version, pg_password, isolation_level


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number