### PR TITLE
fix py312 `datetime.utcnow` warning

### DIFF
--- a/newsfragments/896.bugfix.rst
+++ b/newsfragments/896.bugfix.rst
@@ -1,0 +1,1 @@
+Add your info here

--- a/newsfragments/896.bugfix.rst
+++ b/newsfragments/896.bugfix.rst
@@ -1,1 +1,1 @@
-Add your info here
+Fix the remaining `DepcrecationWarning` for `datetime.datetime.utcnow` on Python 3.12.

--- a/pytest_postgresql/retry.py
+++ b/pytest_postgresql/retry.py
@@ -31,7 +31,7 @@ def retry(
             res = func()
             return res
         except possible_exception as e:
-            if time + timeout_diff < datetime.datetime.utcnow():
+            if time + timeout_diff < get_current_datetime():
                 raise TimeoutError(f"Failed after {i} attempts") from e
             sleep(1)
 


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number