### PR TITLE
Allow the postgresql client to have user-specified scope

### DIFF
--- a/newsfragments/897.feature.rst
+++ b/newsfragments/897.feature.rst
@@ -1,0 +1,1 @@
+Add your info here

--- a/pytest_postgresql/factories/client.py
+++ b/pytest_postgresql/factories/client.py
@@ -22,6 +22,7 @@ from typing import Callable, Iterator, List, Optional, Union
 
 import psycopg
 import pytest
+from _pytest.scope import _ScopeName
 from psycopg import Connection
 from pytest import FixtureRequest
 
@@ -33,6 +34,7 @@ from pytest_postgresql.janitor import DatabaseJanitor
 def postgresql(
     process_fixture_name: str,
     dbname: Optional[str] = None,
+    scope: _ScopeName = "function",
     load: Optional[List[Union[Callable, str, Path]]] = None,
     isolation_level: "Optional[psycopg.IsolationLevel]" = None,
 ) -> Callable[[FixtureRequest], Iterator[Connection]]:
@@ -40,6 +42,7 @@ def postgresql(
 
     :param process_fixture_name: name of the process fixture
     :param dbname: database name
+    :param scope: which scope the fixture should be created for
     :param load: SQL, function or function import paths to automatically load
                  into our test database
     :param isolation_level: optional postgresql isolation level
@@ -47,7 +50,7 @@ def postgresql(
     :returns: function which makes a connection to postgresql
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope=scope)
     def postgresql_factory(request: FixtureRequest) -> Iterator[Connection]:
         """Fixture factory for PostgreSQL.
 


### PR DESCRIPTION
Fixes #895. I could see an argument for not accepting this but it seemed like a straightforward contribution, as well as provide better semantic interoperability with libraries like Django.

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number