### PR TITLE
Fix typos again

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.rst
+++ b/.github/PULL_REQUEST_TEMPLATE.rst
@@ -2,4 +2,4 @@ Chore that needs to be done:
 
 * [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`
 
-Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number
+Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number

--- a/README.rst
+++ b/README.rst
@@ -476,7 +476,7 @@ it'll be on a docker machine or running remotely or locally.
 Using SQLAlchemy to initialise basic database state
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-How to use SQLAlchemy for common initalisation:
+How to use SQLAlchemy for common initialisation:
 
 .. code-block:: python
 

--- a/newsfragments/865.misc.rst
+++ b/newsfragments/865.misc.rst
@@ -2,7 +2,7 @@ Fix DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled f
 
 `datetime.datetime.utcnow` has been deprecated by Python and will soon be removed by Python 3.14 (see warning text below)
 
-The following warning used to pop up everytime someone with a recent version of Python (3.12+) uses this plugin
+The following warning used to pop up every time someone with a recent version of Python (3.12+) uses this plugin
 
 .. code-block::
 

--- a/newsfragments/900.misc.rst
+++ b/newsfragments/900.misc.rst
@@ -1,0 +1,1 @@
+Fix typos found via `codespell -H`

--- a/pytest_postgresql/config.py
+++ b/pytest_postgresql/config.py
@@ -47,7 +47,7 @@ def get_config(request: FixtureRequest) -> PostgresqlConfigDict:
 
 
 def detect_paths(load_paths: List[str]) -> List[Union[Path, str]]:
-    """Covnerts path to sql files to Path instances."""
+    """Convert path to sql files to Path instances."""
     converted_load_paths: List[Union[Path, str]] = []
     for path in load_paths:
         if path.endswith(".sql"):

--- a/tests/examples/test_postgres_options.py
+++ b/tests/examples/test_postgres_options.py
@@ -7,7 +7,7 @@ from typing import Any
 
 
 def test_postgres_options(postgresql: Any) -> None:
-    """Check if the max_connections is set as defined in mater test."""
+    """Check if the max_connections is set as defined in master test."""
     cur = postgresql.cursor()
     cur.execute("SHOW max_connections")
     assert cur.fetchone() == ("16",)


### PR DESCRIPTION
Found via `codespell -H`

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number