### PR TITLE
Accept only keyword arguments in DatabaseJanitor - closes #899

### DIFF
--- a/newsfragments/899.break.rst
+++ b/newsfragments/899.break.rst
@@ -1,0 +1,1 @@
+DatabaseJanitor class now accepts only keyword arguments.

--- a/pytest_postgresql/janitor.py
+++ b/pytest_postgresql/janitor.py
@@ -23,6 +23,7 @@ class DatabaseJanitor:
 
     def __init__(
         self,
+        *,
         user: str,
         host: str,
         port: Union[str, int],


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
