### PR TITLE
Add missing python 3.12 classifier - closes #915

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ CHANGELOG
 
 .. towncrier release notes start
 
+5.1.1 (2024-03-07)
+==================
+
+Miscellaneus
+------------
+
+- Add missing python 3.12 classifier to pythin package. (`#915 <https://github.com/ClearcodeHQ/pytest-postgresql/issues/915>`__)
+
+
 5.1.0 (2024-01-29)
 ==================
 

--- a/newsfragments/915.misc.rst
+++ b/newsfragments/915.misc.rst
@@ -1,1 +1,0 @@
-Add missing python 3.12 classifier to pythin package.

--- a/newsfragments/915.misc.rst
+++ b/newsfragments/915.misc.rst
@@ -1,0 +1,1 @@
+Add missing python 3.12 classifier to pythin package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-postgresql"
-version = "5.1.0"
+version = "5.1.1"
 description = "Postgresql fixtures and fixture factories for Pytest."
 readme = "README.rst"
 keywords = ["tests", "pytest", "fixture", "postgresql"]
@@ -39,7 +39,7 @@ requires-python = ">= 3.8"
 [project.urls]
 "Source" = "https://github.com/ClearcodeHQ/pytest-postgresql"
 "Bug Tracker" = "https://github.com/ClearcodeHQ/pytest-postgresql/issues"
-"Changelog" = "https://github.com/ClearcodeHQ/pytest-postgresql/blob/v5.1.0/CHANGES.rst"
+"Changelog" = "https://github.com/ClearcodeHQ/pytest-postgresql/blob/v5.1.1/CHANGES.rst"
 
 [project.entry-points."pytest11"]
 pytest_postgresql = "pytest_postgresql.plugin"
@@ -104,7 +104,7 @@ name = "Miscellaneus"
 showcontent = true
 
 [tool.tbump.version]
-current = "5.1.0"
+current = "5.1.1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/pytest_postgresql/__init__.py
+++ b/pytest_postgresql/__init__.py
@@ -18,4 +18,4 @@
 # along with pytest-postgresql. If not, see <http://www.gnu.org/licenses/>.
 """Main module for pytest-postgresql."""
 
-__version__ = "5.1.0"
+__version__ = "5.1.1"


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
