### PR TITLE
Template databases are created with is_template flag not allow_connec…

### DIFF
--- a/newsfragments/914.feature.rst
+++ b/newsfragments/914.feature.rst
@@ -1,0 +1,1 @@
+Template databases are now created with is_template flag turned on, and not by setting allow_connections to false.

--- a/pytest_postgresql/janitor.py
+++ b/pytest_postgresql/janitor.py
@@ -68,11 +68,10 @@ class DatabaseJanitor:
         with self.cursor() as cur:
             if self.is_template():
                 cur.execute(f'CREATE DATABASE "{self.template_dbname}";')
+                cur.execute(f'ALTER DATABASE "{self.template_dbname}" with is_template true;')
             elif self.template_dbname is None:
                 cur.execute(f'CREATE DATABASE "{self.dbname}";')
             else:
-                # All template database does not allow connection:
-                self._dont_datallowconn(cur, self.template_dbname)
                 # And make sure no-one is left connected to the template database.
                 # Otherwise, Creating database from template will fail
                 self._terminate_connection(cur, self.template_dbname)
@@ -91,6 +90,8 @@ class DatabaseJanitor:
         with self.cursor() as cur:
             self._dont_datallowconn(cur, db_to_drop)
             self._terminate_connection(cur, db_to_drop)
+            if self.is_template():
+                cur.execute(f'ALTER DATABASE "{db_to_drop}" with is_template false;')
             cur.execute(f'DROP DATABASE IF EXISTS "{db_to_drop}";')
 
     @staticmethod


### PR DESCRIPTION
…tions to false - closes #914

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
