### PR TITLE
Drop python 3.9 from macos tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     with:
       postgresql: 16
       os: macos-latest
-      python-versions: '["3.9", "3.10", "3.11", "3.12"]'
+      python-versions: '["3.10", "3.11", "3.12"]'
   macos_postgres_15:
     needs: [postgresql_15, macos_postgres_16]
     uses: ./.github/workflows/single-postgres.yml

--- a/newsfragments/945.misc.rst
+++ b/newsfragments/945.misc.rst
@@ -1,0 +1,1 @@
+Dropped python 3.9 from macosx tests


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
