### PR TITLE
Pass LC and LANG envvars to pg_ctl calls - closes #343

### DIFF
--- a/newsfragments/343.bugfix.rst
+++ b/newsfragments/343.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a long-standing bug, where calls to pg_ctl weren't getting `LC_*` and `LANG` envvars,
+which caused issues on some systems not recognizing --auth parameter.

--- a/pytest_postgresql/executor.py
+++ b/pytest_postgresql/executor.py
@@ -177,11 +177,13 @@ class PostgreSQLExecutor(TCPExecutor):
                 password_file.write(password)
                 password_file.flush()
                 init_directory += ["-o", " ".join(options)]
-                subprocess.check_output(init_directory)
+                # Passing envvars to command to avoid weird MacOs error.
+                subprocess.check_output(init_directory, env=self._envvars)
         else:
             options += ["--auth=trust"]
             init_directory += ["-o", " ".join(options)]
-            subprocess.check_output(init_directory)
+            # Passing envvars to command to avoid weird MacOs error.
+            subprocess.check_output(init_directory, env=self._envvars)
 
         self._directory_initialised = True
 


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
