### PR TITLE
Permit variable-level scopes for client fixture.

### DIFF
--- a/pytest_postgresql/factories/client.py
+++ b/pytest_postgresql/factories/client.py
@@ -32,6 +32,7 @@ from pytest_postgresql.janitor import DatabaseJanitor
 
 def postgresql(
     process_fixture_name: str,
+    scope: str = 'function',
     dbname: Optional[str] = None,
     load: Optional[List[Union[Callable, str, Path]]] = None,
     isolation_level: "Optional[psycopg.IsolationLevel]" = None,
@@ -47,7 +48,7 @@ def postgresql(
     :returns: function which makes a connection to postgresql
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope=scope)
     def postgresql_factory(request: FixtureRequest) -> Iterator[Connection]:
         """Fixture factory for PostgreSQL.
 


### PR DESCRIPTION
Sometimes a user might not *want* the client fixture to be function-scoped. For example, another fixture may rely on the connection info of the client, such as port-number, and might want that data to remain static throughout a session, or might need that data in a session-scoped fixture.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
