### PR TITLE
add support for `\` character in pytest temporary path - closes #982

### DIFF
--- a/newsfragments/982.misc.rst
+++ b/newsfragments/982.misc.rst
@@ -1,0 +1,1 @@
+add support for \\ character in pytest temporary path

--- a/pytest_postgresql/executor.py
+++ b/pytest_postgresql/executor.py
@@ -49,11 +49,11 @@ class PostgreSQLExecutor(TCPExecutor):
     """
 
     BASE_PROC_START_COMMAND = (
-        "{executable} start -D {datadir} "
+        '{executable} start -D "{datadir}" '
         "-o \"-F -p {port} -c log_destination='stderr' "
         "-c logging_collector=off "
         "-c unix_socket_directories='{unixsocketdir}' {postgres_options}\" "
-        "-l {logfile} {startparams}"
+        '-l "{logfile}" {startparams}'
     )
 
     VERSION_RE = re.compile(r".* (?P<version>\d+(?:\.\d+)?)")
@@ -214,13 +214,13 @@ class PostgreSQLExecutor(TCPExecutor):
         """Check if server is running."""
         if not os.path.exists(self.datadir):
             return False
-        status_code = subprocess.getstatusoutput(f"{self.executable} status -D {self.datadir}")[0]
+        status_code = subprocess.getstatusoutput(f'{self.executable} status -D "{self.datadir}"')[0]
         return status_code == 0
 
     def stop(self: T, sig: Optional[int] = None, exp_sig: Optional[int] = None) -> T:
         """Issue a stop request to executable."""
         subprocess.check_output(
-            f"{self.executable} stop -D {self.datadir} -m f",
+            f'{self.executable} stop -D "{self.datadir}" -m f',
             shell=True,
         )
         try:

--- a/tests/test_postgresql__bad_tmp.py
+++ b/tests/test_postgresql__bad_tmp.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+import pytest
+import tests.test_postgresql
+
+
+@pytest.fixture(scope="session")
+def tmp_path_factory(tmp_path_factory: Union[pytest.TempPathFactory]):
+    r"""overrides the pytest factory to include the \ character"""
+    with tmp_path_factory.mktemp(r"bad\path") as tmp:
+        pytest.TempPathFactory(tmp, retention_count=0, retention_policy="none", trace=None)
+
+
+# we want to redo this test but with the custom tmp_path_factory (\)
+test_postgresql_proc__bad_path = tests.test_postgresql.test_postgresql_proc


### PR DESCRIPTION
add support for `\` character in pytest temporary path - closes #982

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
