### PR TITLE
Refactor executor test for macOS and LC_ALL tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 pytest = "==8.3.2"
-port-for = "==0.7.2"
+port-for = "==0.7.3"
 mirakuru = "==2.5.2"
 psycopg = "==3.2.1"
 

--- a/newsfragments/+7b24253a.misc.rst
+++ b/newsfragments/+7b24253a.misc.rst
@@ -1,0 +1,1 @@
+Add test for `PR #965 <https://github.com/ClearcodeHQ/pytest-postgresql/pull/965>`_

--- a/newsfragments/+a32d1721.misc.rst
+++ b/newsfragments/+a32d1721.misc.rst
@@ -1,0 +1,1 @@
+refactors test_executor.py to enable Mac

--- a/pytest_postgresql/factories/__init__.py
+++ b/pytest_postgresql/factories/__init__.py
@@ -19,6 +19,6 @@
 
 from pytest_postgresql.factories.client import postgresql
 from pytest_postgresql.factories.noprocess import postgresql_noproc
-from pytest_postgresql.factories.process import postgresql_proc
+from pytest_postgresql.factories.process import PortType, postgresql_proc
 
-__all__ = ("postgresql_proc", "postgresql_noproc", "postgresql")
+__all__ = ("postgresql_proc", "postgresql_noproc", "postgresql", "PortType")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -68,7 +68,7 @@ def test_unsupported_version(request: FixtureRequest) -> None:
         executor.start()
 
 
-@pytest.mark.parametrize("locale", ("en_US.UTF-8", "de_DE.UTF-8"))
+@pytest.mark.parametrize("locale", ("en_US.UTF-8", "de_DE.UTF-8", "nl_NO.UTF-8"))
 def test_executor_init_with_password(
     request: FixtureRequest,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Changes made
1. Adds a test for your recent PR (#965).
2. refactors the test to remove the `skipif` for `Darwin`.

I think my solution is still less than ideal so I left the implementation details underscored (`_`).
Maybe something like builder pattern  or  `PostgreSQLExecutor(**config)` would be good.


## Testing
1. I was able to verify your PR #965 does in fact fix the issue the user encounted.
   * before 965 PR: 
   ![image](https://github.com/user-attachments/assets/b5b567a8-def6-4106-8bc4-c8e6017369c9)
   * after 965 PR: 
   ![image](https://github.com/user-attachments/assets/e73d584e-70a0-4a52-9524-d10efa37a856)

2. tested on a mac to verify that the latest code runs.

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
