### PR TITLE
misc: declare `packaging` dependency explicitly

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 pytest = "==8.3.4"
 port-for = "==0.7.4"
 mirakuru = "==2.5.3"
+packaging = "==24.2"
 psycopg = "==3.2.3"
 
 [dev-packages]
@@ -16,7 +17,7 @@ pytest-xdist = "==3.6.1"
 mock = "==5.1.0"
 black = "==24.10.0"
 mypy = "==1.14.0"
-types-setuptools = "==75.6.0.20241223"
+setuptools = "==75.6.0"
 tbump = "==6.11.0"
 ruff = "==0.8.4"
 rstcheck = {version = "==6.2.4", extras = ["sphinx", "toml"]}

--- a/newsfragments/1048.misc.rst
+++ b/newsfragments/1048.misc.rst
@@ -1,0 +1,4 @@
+In #858 the runtime dependency on `setuptools` was replaced with `packaging`,
+which is currently installed as a transitive dependency of other dependencies.
+Make `packaging` dependency explicit to prevent accidental breakage
+in the event it is removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pytest >= 6.2",
     "port-for >= 0.7.3",
     "mirakuru",
-    "setuptools",
+    "packaging",
     "psycopg >= 3.0.0"
 ]
 requires-python = ">= 3.9"


### PR DESCRIPTION
In #858 the runtime dependency on `setuptools` was replaced with `packaging`, which is currently installed as a transitive dependency of other dependencies.
Make `packaging` dependency explicit to prevent accidental breakage in the event it is removed.