### PR TITLE
misc: resolve deprecation warning for `str.split()`

### DIFF
--- a/newsfragments/+0ff2173d.misc.rst
+++ b/newsfragments/+0ff2173d.misc.rst
@@ -1,0 +1,3 @@
+In Python 3.13, usage of a positional argument for `maxsplit` has been
+formally deprecated.
+Update code to use keyword argument `maxsplit` instead of positional.

--- a/pytest_postgresql/loader.py
+++ b/pytest_postgresql/loader.py
@@ -13,7 +13,7 @@ def build_loader(load: Union[Callable, str, Path]) -> Callable:
     if isinstance(load, Path):
         return partial(sql, load)
     elif isinstance(load, str):
-        loader_parts = re.split("[.:]", load, 2)
+        loader_parts = re.split("[.:]", load, maxsplit=2)
         import_path = ".".join(loader_parts[:-1])
         loader_name = loader_parts[-1]
         _temp_import = __import__(import_path, globals(), locals(), fromlist=[loader_name])


### PR DESCRIPTION
In Python 3.13, usage of a positional argument for `maxsplit` has been formally deprecated.
Refs: https://github.com/python/cpython/pull/107778

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
