### PR TITLE
Skip pre-commit checks for pre-commit actor

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,7 +16,7 @@ jobs:
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ !contains(fromJSON('["dependabot[bot]","pre-commit-ci"]'), github.actor) }}
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:

--- a/newsfragments/+a82453f2.misc.rst
+++ b/newsfragments/+a82453f2.misc.rst
@@ -1,0 +1,1 @@
+Skip newsfragment checks for pre-commit actor.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
