### PR TITLE
Pass all environment variables to initdb - closes #1076

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 pytest = "==8.3.4"
 port-for = "==0.7.4"
-mirakuru = "==2.5.3"
+mirakuru = "==2.6.0"
 packaging = "==24.2"
 psycopg = "==3.2.4"
 

--- a/newsfragments/1076.bugfix.rst
+++ b/newsfragments/1076.bugfix.rst
@@ -1,0 +1,4 @@
+Passing all environment variables to the initdb.
+
+This helps the cases where og_ctl is replaced by custom shell script
+making additional calls, and needs all the variables, that ie server process gets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "pytest >= 6.2",
     "port-for >= 0.7.3",
-    "mirakuru",
+    "mirakuru >= 2.6.0",
     "packaging",
     "psycopg >= 3.0.0"
 ]

--- a/pytest_postgresql/executor.py
+++ b/pytest_postgresql/executor.py
@@ -178,12 +178,12 @@ class PostgreSQLExecutor(TCPExecutor):
                 password_file.flush()
                 init_directory += ["-o", " ".join(options)]
                 # Passing envvars to command to avoid weird MacOs error.
-                subprocess.check_output(init_directory, env=self._envvars)
+                subprocess.check_output(init_directory, env=self.envvars)
         else:
             options += ["--auth=trust"]
             init_directory += ["-o", " ".join(options)]
             # Passing envvars to command to avoid weird MacOs error.
-            subprocess.check_output(init_directory, env=self._envvars)
+            subprocess.check_output(init_directory, env=self.envvars)
 
         self._directory_initialised = True
 


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
