### PR TITLE
Drop support for loading schema and data fixture from client fixture …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,45 +90,20 @@ Pre-populating the database for tests
 
 If you want the database fixture to be automatically pre-populated with your schema and data, there are two lewels you can achieve it:
 
-#. per test in a client fixture
+#. per test in a client fixture, by an intermediary fixture between client and your test (or other fixtures)
 #. per session in a process fixture
 
-Both fixtures are accepting same set of possible loaders:
+The process fixture accepts a load parameter, which accepts these loaders:
 
 * sql file path - which will load and execute sql files
-* loading functions - either by string import path, actual callable.  Loading functions will receive **host**, **port**, **user**, **dbname** and **password** arguments and will have to perform
+* loading functions - either by string import path, actual callable.
+  Loading functions will receive **host**, **port**, **user**, **dbname** and **password** arguments and will have to perform
   connection to the database inside. Or start session in the ORM of your choice to perform actions with given ORM.
   This way, you'd be able to trigger ORM based data manipulations, or even trigger database migrations programmatically.
 
-
-Per test in a client fixture
-++++++++++++++++++++++++++++
-
-Client fixture loads are performed the database each test. Are useful if you create several clients for single process fixture.
-
-
-.. code-block:: python
-
-    from pathlib import Path
-    postgresql_my_with_schema = factories.postgresql(
-        'postgresql_my_proc',
-        load=[Path("schemafile.sql"), Path("otherschema.sql"), "import.path.to.function", "import.path.to:otherfunction", load_this]
-    )
-
-.. warning::
-
-    The database is dropped after each test and before each test using this fixture, it will load the schema/data again.
-
-.. warning::
-
-    client level pre-population is deprecated. Same functionality can be achieved by intermediary fixture between client and test itself.
-
-
-Per session in a process fixture
-++++++++++++++++++++++++++++++++
-
-The process fixture pre-populates the database once per test session, and loads the schema and data into the template database.
-Client fixture then creates test database out of the template database each test, which significantly **speeds up the tests**.
+The process fixture pre-populates the database once per test session (at the start of the process fixture),
+and loads the schema and data into the template database. Client fixture then creates test database out of the template database each test,
+which significantly **speeds up the tests**.
 
 .. code-block:: python
 
@@ -138,7 +113,7 @@ Client fixture then creates test database out of the template database each test
     )
 
 Additional benefit, is that test code might safely use separate database connection, and can safely test it's behaviour with transactions and rollbacks,
-as tests and code will work on separate database client instances.
+as tests and code will work on separate database connections.
 
 Defining pre-populate on command line:
 

--- a/newsfragments/1087.break.rst
+++ b/newsfragments/1087.break.rst
@@ -1,0 +1,1 @@
+Drop support for load parameter from client fixtures. This can be easily replaced by creating intermediary fixture between test and client fixture.

--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -133,12 +133,14 @@ def postgresql_proc(
         while True:
             try:
                 pg_port = _pg_port(port, config, used_ports)
+                port_filename_path = port_path / f"postgresql-{pg_port}.port"
                 if pg_port in used_ports:
                     raise PortForException(
-                        f"Port {pg_port} already in use, probably by other instances of the test."
+                        f"Port {pg_port} already in use, probably by other instances of the test. "
+                        f"{port_filename_path} is already used."
                     )
                 used_ports.add(pg_port)
-                with (port_path / f"postgresql-{pg_port}.port").open("x") as port_file:
+                with (port_filename_path).open("x") as port_file:
                     port_file.write(f"pg_port {pg_port}\n")
                 break
             except FileExistsError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,17 +14,6 @@ TEST_SQL_DIR = os.path.dirname(os.path.abspath(__file__)) + "/test_sql/"
 TEST_SQL_FILE = Path(TEST_SQL_DIR + "test.sql")
 TEST_SQL_FILE2 = Path(TEST_SQL_DIR + "test2.sql")
 
-postgresql_proc2 = factories.postgresql_proc(port=None)
+postgresql_proc2 = factories.postgresql_proc(port=None, load=[TEST_SQL_FILE, TEST_SQL_FILE2])
 postgresql2 = factories.postgresql("postgresql_proc2", dbname="test-db")
-postgresql_load_1 = factories.postgresql(
-    "postgresql_proc2",
-    dbname="test-load-db",
-    load=[
-        TEST_SQL_FILE,
-    ],
-)
-postgresql_load_2 = factories.postgresql(
-    "postgresql_proc2",
-    dbname="test-load-moredb",
-    load=[TEST_SQL_FILE, TEST_SQL_FILE2],
-)
+postgresql_load_1 = factories.postgresql("postgresql_proc2")

--- a/tests/docker/test_noproc_docker.py
+++ b/tests/docker/test_noproc_docker.py
@@ -1,5 +1,7 @@
 """Noproc fixture tests."""
 
+import pathlib
+
 import pytest
 from psycopg import Connection
 
@@ -7,10 +9,10 @@ import pytest_postgresql.factories.client
 import pytest_postgresql.factories.noprocess
 from tests.loader import load_database
 
-postgresql_my_proc = pytest_postgresql.factories.noprocess.postgresql_noproc()
-postgres_with_schema = pytest_postgresql.factories.client.postgresql(
-    "postgresql_my_proc", dbname="test"
+postgresql_my_proc = pytest_postgresql.factories.noprocess.postgresql_noproc(
+    load=[pathlib.Path("tests/test_sql/eidastats.sql")]
 )
+postgres_with_schema = pytest_postgresql.factories.client.postgresql("postgresql_my_proc")
 
 postgresql_my_proc_template = pytest_postgresql.factories.noprocess.postgresql_noproc(
     dbname="stories_templated", load=[load_database]

--- a/tests/docker/test_noproc_docker.py
+++ b/tests/docker/test_noproc_docker.py
@@ -1,7 +1,5 @@
 """Noproc fixture tests."""
 
-import pathlib
-
 import pytest
 from psycopg import Connection
 
@@ -11,7 +9,7 @@ from tests.loader import load_database
 
 postgresql_my_proc = pytest_postgresql.factories.noprocess.postgresql_noproc()
 postgres_with_schema = pytest_postgresql.factories.client.postgresql(
-    "postgresql_my_proc", dbname="test", load=[pathlib.Path("tests/test_sql/eidastats.sql")]
+    "postgresql_my_proc", dbname="test"
 )
 
 postgresql_my_proc_template = pytest_postgresql.factories.noprocess.postgresql_noproc(

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -11,7 +11,7 @@ from pytest_postgresql.retry import retry
 from tests.conftest import POSTGRESQL_VERSION
 
 MAKE_Q = "CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);"
-SELECT_Q = "SELECT * FROM test;"
+SELECT_Q = "SELECT * FROM test_load;"
 
 
 def test_postgresql_proc(postgresql_proc: PostgreSQLExecutor) -> None:
@@ -40,18 +40,9 @@ def test_two_postgreses(postgresql: Connection, postgresql2: Connection) -> None
     cur.close()
 
 
-def test_postgres_load_one_file(postgresql_load_1: Connection) -> None:
-    """Check postgresql fixture can load one file."""
-    cur = postgresql_load_1.cursor()
-    cur.execute(SELECT_Q)
-    results = cur.fetchall()
-    assert len(results) == 1
-    cur.close()
-
-
-def test_postgres_load_two_files(postgresql_load_2: Connection) -> None:
+def test_postgres_load_two_files(postgresql_load_1: Connection) -> None:
     """Check postgresql fixture can load two files."""
-    cur = postgresql_load_2.cursor()
+    cur = postgresql_load_1.cursor()
     cur.execute(SELECT_Q)
     results = cur.fetchall()
     assert len(results) == 2

--- a/tests/test_sql/test.sql
+++ b/tests/test_sql/test.sql
@@ -1,2 +1,2 @@
-CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);
-INSERT INTO test VALUES(1, 2, 'c');
+CREATE TABLE test_load (id serial PRIMARY KEY, num integer, data varchar);
+INSERT INTO test_load VALUES(1, 2, 'c');

--- a/tests/test_sql/test2.sql
+++ b/tests/test_sql/test2.sql
@@ -1,1 +1,1 @@
-INSERT INTO test VALUES(2, 1, 'z');
+INSERT INTO test_load VALUES(2, 1, 'z');


### PR DESCRIPTION
…- closes #1087

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
