### PR TITLE
Fix issue where --postgresql-drop-test-database was not applied every…

### DIFF
--- a/newsfragments/1148.bugfix.rst
+++ b/newsfragments/1148.bugfix.rst
@@ -1,0 +1,3 @@
+Fix issue where `--postgresql-drop-test-database` was applied in process fixture.
+
+It was already being read in client and noprocess fixtures.

--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -166,14 +166,17 @@ def postgresql_proc(
         # start server
         with postgresql_executor:
             postgresql_executor.wait_for_postgres()
-            with DatabaseJanitor(
+            janitor = DatabaseJanitor(
                 user=postgresql_executor.user,
                 host=postgresql_executor.host,
                 port=postgresql_executor.port,
                 template_dbname=postgresql_executor.template_dbname,
                 version=postgresql_executor.version,
                 password=postgresql_executor.password,
-            ) as janitor:
+            )
+            if config["drop_test_database"]:
+                janitor.drop()
+            with janitor:
                 for load_element in pg_load:
                     janitor.load(load_element)
                 yield postgresql_executor


### PR DESCRIPTION
…where - closes #1148

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
