### PR TITLE
Allow chaining noprocess fixtures - closes #890

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,33 @@ To connect to an external server (e.g., running in Docker), use the ``postgresql
 
 By default, it connects to ``127.0.0.1:5432``.
 
+Chaining fixtures
+-----------------
+
+You can chain multiple ``postgresql_noproc`` fixtures to layer your data pre-population. Each fixture in the chain will create its own template database based on the previous one.
+
+.. code-block:: python
+
+    from pytest_postgresql import factories
+
+    # 1. Start with a process or a no-process base
+    base_proc = factories.postgresql_proc(load=[load_schema])
+
+    # 2. Add a layer with some data
+    seeded_noproc = factories.postgresql_noproc(depends_on="base_proc", load=[load_data])
+
+    # 3. Add another layer with more data
+    more_seeded_noproc = factories.postgresql_noproc(depends_on="seeded_noproc", load=[load_more_data])
+
+    # 4. Use the final layer in your test
+    client = factories.postgresql("more_seeded_noproc")
+
+
+
+.. image:: https://raw.githubusercontent.com/dbfixtures/pytest-postgresql/main/docs/images/architecture_chaining.svg
+    :alt: Fixture Chaining Diagram
+    :align: center
+
 Configuration
 =============
 

--- a/docs/architecture_chaining.mmd
+++ b/docs/architecture_chaining.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+        participant Test as Test
+        participant ProcF as base_proc Fixture
+        participant NoProc1 as seeded_noproc Fixture
+        participant NoProc2 as more_seeded_noproc Fixture
+        participant DB as PostgreSQL DB
+
+        Test->>ProcF: request base_proc
+        ProcF->>DB: init database & run load_schema
+        ProcF-->>Test: return PostgreSQLExecutor
+
+        Test->>NoProc1: request seeded_noproc (depends_on=base_proc)
+        NoProc1->>ProcF: read connection/template info
+        NoProc1->>DB: create layered DB / run load_data
+        NoProc1-->>Test: return NoopExecutor
+
+        Test->>NoProc2: request more_seeded_noproc (depends_on=seeded_noproc)
+        NoProc2->>NoProc1: read connection/template info
+        NoProc2->>DB: run load_more_data on layered DB
+        NoProc2-->>Test: return NoopExecutor
+
+        Test->>Test: validate tables and data across layers

--- a/newsfragments/890.break.1.rst
+++ b/newsfragments/890.break.1.rst
@@ -1,0 +1,5 @@
+Bump the minimum supported pytest version to 8.2.
+
+The previous minimum was about two years old, and older pytest versions
+can be flaky with fixture chaining that relies on `getfixturevalue` on
+Python 3.12-3.13 when used alongside xdist.

--- a/newsfragments/890.break.rst
+++ b/newsfragments/890.break.rst
@@ -1,0 +1,1 @@
+Refactor ``DatabaseJanitor`` to use explicit template management. This includes a new ``as_template`` flag and making ``dbname`` a required parameter.

--- a/newsfragments/890.docs.rst
+++ b/newsfragments/890.docs.rst
@@ -1,0 +1,1 @@
+Add a Mermaid sequence diagram to the documentation to illustrate fixture chaining and hierarchical cloning.

--- a/newsfragments/890.feature.rst
+++ b/newsfragments/890.feature.rst
@@ -1,0 +1,1 @@
+Add ``depends_on`` parameter to ``postgresql_noproc`` factory to allow hierarchical cloning and chaining of process fixtures.

--- a/oldest/requirements.txt
+++ b/oldest/requirements.txt
@@ -1,5 +1,4 @@
-pytest == 7.4; python_version >= "3.14"
-pytest == 7.2; python_version < "3.14"
+pytest == 8.2
 port-for == 0.7.3
 mirakuru == 2.6.0
 psycopg == 3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest >= 7.2",
+    "pytest >= 8.2",
     "port-for >= 0.7.3",
     "mirakuru >= 2.6.0",
     "packaging",

--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -170,7 +170,8 @@ def postgresql_proc(
                 user=postgresql_executor.user,
                 host=postgresql_executor.host,
                 port=postgresql_executor.port,
-                template_dbname=postgresql_executor.template_dbname,
+                dbname=postgresql_executor.template_dbname,
+                as_template=True,
                 version=postgresql_executor.version,
                 password=postgresql_executor.password,
             )

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -1,0 +1,101 @@
+"""Chaining noprocess fixtures tests for pytest-postgresql."""
+
+import psycopg
+
+from pytest_postgresql import factories
+from pytest_postgresql.executor import PostgreSQLExecutor
+from pytest_postgresql.executor_noop import NoopExecutor
+
+
+def load_schema(host: str, port: int, user: str, dbname: str, password: str | None) -> None:
+    """Load schema into the database."""
+    with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE TABLE schema_table (id serial PRIMARY KEY, name varchar);")
+            conn.commit()
+
+
+def load_data(host: str, port: int, user: str, dbname: str, password: str | None) -> None:
+    """Load the first layer of data into the database."""
+    with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO schema_table (name) VALUES ('data_layer');")
+            cur.execute("CREATE TABLE data_table (id serial PRIMARY KEY, val varchar);")
+            conn.commit()
+
+
+def load_more_data(host: str, port: int, user: str, dbname: str, password: str | None) -> None:
+    """Load the second layer of data into the database."""
+    with psycopg.connect(host=host, port=port, user=user, dbname=dbname, password=password) as conn:
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO schema_table (name) VALUES ('more_data_layer');")
+            cur.execute("CREATE TABLE more_data_table (id serial PRIMARY KEY, extra varchar);")
+            conn.commit()
+
+
+# Chaining: proc -> noproc -> client
+base_proc = factories.postgresql_proc(load=[load_schema])
+seeded_noproc = factories.postgresql_noproc(depends_on="base_proc", load=[load_data])
+client_layered = factories.postgresql("seeded_noproc")
+
+# Deeper chaining: proc -> noproc -> noproc -> client
+more_seeded_noproc = factories.postgresql_noproc(depends_on="seeded_noproc", load=[load_more_data])
+client_deep_layered = factories.postgresql("more_seeded_noproc")
+
+
+def test_chaining_two_layers(client_layered: psycopg.Connection) -> None:
+    """Test that data from both proc and noproc layers is present."""
+    with client_layered.cursor() as cur:
+        # From base_proc (load_schema)
+        cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_name = 'schema_table';")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == 1
+
+        # From seeded_noproc (load_data)
+        cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_name = 'data_table';")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == 1
+
+        # Data inserted in seeded_noproc
+        cur.execute("SELECT name FROM schema_table;")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == "data_layer"
+
+
+def test_chaining_three_layers(client_deep_layered: psycopg.Connection) -> None:
+    """Test that data from all three layers is present."""
+    with client_deep_layered.cursor() as cur:
+        # From base_proc
+        cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_name = 'schema_table';")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == 1
+
+        # From seeded_noproc
+        cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_name = 'data_table';")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == 1
+
+        # From more_seeded_noproc
+        cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_name = 'more_data_table';")
+        res = cur.fetchone()
+        assert res
+        assert res[0] == 1
+
+        # Data from multiple layers
+        cur.execute("SELECT name FROM schema_table ORDER BY id;")
+        results = cur.fetchall()
+        assert results[0][0] == "data_layer"
+        assert results[1][0] == "more_data_layer"
+
+
+def test_inheritance(base_proc: PostgreSQLExecutor, seeded_noproc: NoopExecutor) -> None:
+    """Verify that connection parameters are inherited from the base fixture."""
+    assert seeded_noproc.host == base_proc.host
+    assert seeded_noproc.port == base_proc.port
+    assert seeded_noproc.user == base_proc.user
+    assert seeded_noproc.password == base_proc.password

--- a/tests/test_postgres_options_plugin.py
+++ b/tests/test_postgres_options_plugin.py
@@ -95,20 +95,21 @@ def test_postgres_drop_test_database(
         user=postgresql_proc_to_override.user,
         host=postgresql_proc_to_override.host,
         port=postgresql_proc_to_override.port,
-        template_dbname=template_dbname,
+        dbname=template_dbname,
+        as_template=True,
         version=postgresql_proc_to_override.version,
         password=postgresql_proc_to_override.password,
         connection_timeout=5,
     )
     template_janitor.init()
     template_janitor.load(load_database)
-    assert template_janitor.template_dbname
+    assert template_janitor.dbname
     janitor = DatabaseJanitor(
         user=postgresql_proc_to_override.user,
         host=postgresql_proc_to_override.host,
         port=postgresql_proc_to_override.port,
         dbname=dbname,
-        template_dbname=template_janitor.template_dbname,
+        template_dbname=template_janitor.dbname,
         version=postgresql_proc_to_override.version,
         password=postgresql_proc_to_override.password,
         connection_timeout=5,
@@ -137,7 +138,7 @@ def test_postgres_drop_test_database(
     assert hasattr(excinfo.value, "__cause__")
     assert f'FATAL:  database "{janitor.dbname}" does not exist' in str(excinfo.value.__cause__)
     with pytest.raises(TimeoutError) as excinfo:
-        with template_janitor.cursor(template_janitor.template_dbname):
+        with template_janitor.cursor(template_janitor.dbname):
             pass
     assert hasattr(excinfo.value, "__cause__")
-    assert f'FATAL:  database "{template_janitor.template_dbname}" does not exist' in str(excinfo.value.__cause__)
+    assert f'FATAL:  database "{template_janitor.dbname}" does not exist' in str(excinfo.value.__cause__)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,14 +1,11 @@
 """All tests for pytest-postgresql."""
 
-import decimal
-
 import pytest
 from psycopg import Connection
 from psycopg.pq import ConnStatus
 
 from pytest_postgresql.executor import PostgreSQLExecutor
 from pytest_postgresql.retry import retry
-from tests.conftest import POSTGRESQL_VERSION
 
 MAKE_Q = "CREATE TABLE test (id serial PRIMARY KEY, num integer, data varchar);"
 SELECT_Q = "SELECT * FROM test_load;"
@@ -54,10 +51,7 @@ def test_rand_postgres_port(postgresql2: Connection) -> None:
     assert postgresql2.info.status == ConnStatus.OK
 
 
-@pytest.mark.skipif(
-    decimal.Decimal(POSTGRESQL_VERSION) < 10,
-    reason="Test query not supported in those postgresql versions, and soon will not be supported.",
-)
+@pytest.mark.xdist_group(name="terminate_connection")
 @pytest.mark.parametrize("_", range(2))
 def test_postgres_terminate_connection(postgresql2: Connection, _: int) -> None:
     """Test that connections are terminated between tests.


### PR DESCRIPTION
  This allows for more complex test suites with common base data fixture
  Extended for a specific group of tests that needs additional data elements in database

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a depends_on parameter to enable hierarchical fixture chaining for layered database pre-population.

* **Documentation**
  * Added "Chaining fixtures" guidance, examples and an architecture diagram illustrating multi‑layer fixture cloning.

* **Tests**
  * Added tests covering two‑ and three‑layer chaining, data propagation and inheritance of connection parameters.

* **Breaking Changes**
  * Database janitor/template handling updated to explicit template management with an as_template flag.

* **Chores**
  * Minimum pytest requirement bumped to 8.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->