### PR TITLE
Attempt to fix a macos random failure

### DIFF
--- a/newsfragments/+831f24cb.misc.rst
+++ b/newsfragments/+831f24cb.misc.rst
@@ -1,0 +1,4 @@
+Attempt to overcome random failure on CI on MacOS on xdist workers where test_executor_init_with_password is receiving
+`FATAL: the database system is starting up` error message from psycopg.
+
+That's the only test that doesn't have guards against attempting to start on the same port as other xdist worker.

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -68,6 +68,7 @@ def test_unsupported_version(request: FixtureRequest) -> None:
         executor.start()
 
 
+@pytest.mark.xdist_group(name="executor_no_xdist_guard")
 @pytest.mark.parametrize("locale", ("en_US.UTF-8", "de_DE.UTF-8", "nl_NO.UTF-8"))
 def test_executor_init_with_password(
     request: FixtureRequest,


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Optimised test configuration for improved distributed parallel execution across multiple worker processes.

* **Chores**
  * Implemented targeted fixes for intermittent CI nondeterministic failures on MacOS. Addressed database initialisation issues in test execution that previously caused resource conflicts when running tests across distributed workers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->