### PR TITLE
Improve reliability of Coverage reporting on CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
+concurrency = multiprocessing
+parallel = true
 include =
     */pytest_postgresql/*
     */tests/*

--- a/.github/workflows/dockerised-postgres.yml
+++ b/.github/workflows/dockerised-postgres.yml
@@ -55,13 +55,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Run test noproc fixture on docker
+        id: run_docker_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.7
         with:
-          command: pytest -n 0 --max-worker-restart 0 -k docker --postgresql-host=localhost --postgresql-port 5433 --postgresql-password=postgres --cov-report=xml:coverage-docker.xml
+          command: python -m coverage run --data-file=.coverage.docker -m pytest -n 0 --max-worker-restart 0 -k docker --postgresql-host=localhost --postgresql-port 5433 --postgresql-password=postgres
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.docker"}'
+      - name: Combine and export docker coverage
+        if: ${{ always() && (steps.run_docker_tests.conclusion == 'success' || steps.run_docker_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.7
+        with:
+          data-file: .coverage.docker
+          output-file: coverage-docker.xml
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests
           env_vars: OS,PYTHON
           fail_ci_if_error: false
+          files: coverage-docker.xml

--- a/.github/workflows/oldest-postgres.yml
+++ b/.github/workflows/oldest-postgres.yml
@@ -59,22 +59,40 @@ jobs:
         with:
           command: pip install -r oldest/requirements.txt
       - name: Run tests without xdist
+        id: run_serial_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.7
         with:
-          command: pytest -c pyproject.oldest.toml -svv -p no:xdist --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker" --cov-report=xml
+          command: python -m coverage run --data-file=.coverage.serial -m pytest -c pyproject.oldest.toml -svv -p no:xdist --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
+      - name: Combine and export serial coverage
+        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.7
+        with:
+          data-file: .coverage.serial
+          output-file: coverage-serial.xml
       - name: Run xdist test
+        id: run_xdist_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.7
         with:
-          command: pytest -n auto -c pyproject.oldest.toml --dist loadgroup --max-worker-restart 0 --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker" --cov-report=xml:coverage-xdist.xml
+          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto -c pyproject.oldest.toml --dist loadgroup --max-worker-restart 0 --postgresql-exec="/usr/lib/postgresql/${{ inputs.postgresql }}/bin/pg_ctl" -k "not docker"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
+      - name: Combine and export xdist coverage
+        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.7
+        with:
+          data-file: .coverage.xdist
+          output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: postgresql-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: /tmp/pytest-of-runner/**
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests
           env_vars: OS,PYTHON
           fail_ci_if_error: false
+          files: coverage-serial.xml,coverage-xdist.xml

--- a/.github/workflows/single-postgres-windows.yml
+++ b/.github/workflows/single-postgres-windows.yml
@@ -57,22 +57,40 @@ jobs:
             exit 1
           }
       - name: Run test
+        id: run_serial_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.4
         with:
-          command: pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --cov-report=xml --basetemp="${{ runner.temp }}/pytest-basetemp"
+          command: python -m coverage run --data-file=.coverage.serial -m pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
+      - name: Combine and export serial coverage
+        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.4
+        with:
+          data-file: .coverage.serial
+          output-file: coverage-serial.xml
       - name: Run xdist test
+        id: run_xdist_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.4
         with:
-          command: pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --cov-report=xml:coverage-xdist.xml --basetemp="${{ runner.temp }}/pytest-basetemp"
+          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
+      - name: Combine and export xdist coverage
+        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.4
+        with:
+          data-file: .coverage.xdist
+          output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: postgresql-windows-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: ${{ runner.temp }}/pytest-basetemp/**
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests
           env_vars: OS,PYTHON
           fail_ci_if_error: false
+          files: coverage-serial.xml,coverage-xdist.xml

--- a/.github/workflows/single-postgres.yml
+++ b/.github/workflows/single-postgres.yml
@@ -73,22 +73,40 @@ jobs:
         if: ${{ contains(matrix.python-version, 'pypy') && runner.os == 'Linux' }}
         run: sudo apt install libpq5
       - name: Run test
+        id: run_serial_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.7
         with:
-          command: pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --cov-report=xml --basetemp="${{ runner.temp }}/pytest-basetemp"
+          command: python -m coverage run --data-file=.coverage.serial -m pytest -svv -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.serial"}'
+      - name: Combine and export serial coverage
+        if: ${{ always() && (steps.run_serial_tests.conclusion == 'success' || steps.run_serial_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.7
+        with:
+          data-file: .coverage.serial
+          output-file: coverage-serial.xml
       - name: Run xdist test
+        id: run_xdist_tests
         uses: fizyk/actions-reuse/.github/actions/pipenv-run@v4.4.7
         with:
-          command: pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --cov-report=xml:coverage-xdist.xml --basetemp="${{ runner.temp }}/pytest-basetemp"
+          command: python -m coverage run --data-file=.coverage.xdist -m pytest -n auto --dist loadgroup --max-worker-restart 0 --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
+          env: '{"COVERAGE_PROCESS_START": ".coveragerc", "COVERAGE_FILE": ".coverage.xdist"}'
+      - name: Combine and export xdist coverage
+        if: ${{ always() && (steps.run_xdist_tests.conclusion == 'success' || steps.run_xdist_tests.conclusion == 'failure') }}
+        uses: fizyk/actions-reuse/.github/actions/coverage-combine-export@v4.4.7
+        with:
+          data-file: .coverage.xdist
+          output-file: coverage-xdist.xml
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: postgresql-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: ${{ runner.temp }}/pytest-basetemp/**
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests
           env_vars: OS,PYTHON
           fail_ci_if_error: false
+          files: coverage-serial.xml,coverage-xdist.xml

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ pytest-postgresql = {path = ".", editable = true}
 [dev-packages]
 towncrier = "==25.8.0"
 psycopg-binary = {version = "==3.3.4", markers="implementation_name == 'cpython'"}
-pytest-cov = "==7.1.0"
+coverage = ">=7.0"
 pytest-xdist = "==3.8.0"
 mock = "==5.2.0"
 mypy = {version = "==2.1.0", markers="implementation_name == 'cpython'"}

--- a/newsfragments/+4ed991c2.misc.rst
+++ b/newsfragments/+4ed991c2.misc.rst
@@ -1,0 +1,1 @@
+Improve reliability of Coverage reporting on CI

--- a/pyproject.oldest.toml
+++ b/pyproject.oldest.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 xfail_strict=true
-addopts = "--showlocals --verbose --cov"
+addopts = "--showlocals --verbose"
 testpaths = "tests"
 pytester_example_dir = "tests/examples"
 norecursedirs = "examples"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ namespaces = false
 
 [tool.pytest]
 strict_xfail=true
-addopts = ["--showlocals", "--verbose", "--cov"]
+addopts = ["--showlocals", "--verbose"]
 testpaths = ["tests"]
 pytester_example_dir = "tests/examples"
 norecursedirs = ["examples"]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI coverage reporting with improved multiprocessing support for more reliable test coverage collection.
  * Optimised coverage collection across serial and parallel test execution modes.
  * Updated testing infrastructure dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dbfixtures/pytest-postgresql/pull/1337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->