### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -4,9 +4,24 @@ on:
     tags:
       - v*
 jobs:
-  build-n-publish:
+  build:
     uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@v4.4.7
     with:
-      publish: true
-    secrets:
-      pypi_token: ${{ secrets.pypi_password }}
+      publish: false
+
+  publish:
+    name: Publish Python 🐍 distributions 📦 to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions 📦
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          verbose: true

--- a/newsfragments/+13f2182d.misc.rst
+++ b/newsfragments/+13f2182d.misc.rst
@@ -1,0 +1,1 @@
+Migrate package publishing step to trusted publishing.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the package publishing workflow to separate build and publish stages in the continuous integration pipeline. Migrated publishing from token-based authentication to trusted publishing, utilising OpenID Connect for enhanced security and streamlined release procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dbfixtures/pytest-postgresql/pull/1339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->