### PR TITLE
Add pyproject-fmt to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --respect-gitignore, --show-fixes]
       - id: ruff-format
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.25.3
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.5
     hooks:

--- a/newsfragments/+0d5d4cb5.misc.rst
+++ b/newsfragments/+0d5d4cb5.misc.rst
@@ -1,0 +1,1 @@
+Add pyproject-fmt to pre-commit tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,115 +1,148 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=61.0.0" ]
+
 [project]
 name = "pytest-postgresql"
 version = "8.1.0"
 description = "Postgresql fixtures and fixture factories for Pytest."
 readme = "README.rst"
-keywords = ["tests", "pytest", "fixture", "postgresql"]
-license = {file = "COPYING.lesser"}
-authors = [
-    {name = "Grzegorz Śliwiński", email = "fizyk+pypi@fizyk.dev"}
-]
+keywords = [ "fixture", "postgresql", "pytest", "tests" ]
+license = { file = "COPYING.lesser" }
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: Pytest",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
-    "Framework :: Pytest",
 ]
-dependencies = [
-    "pytest >= 8.2",
-    "port-for >= 0.7.3",
-    "mirakuru >= 2.6.0",
-    "packaging",
-    "psycopg >= 3.0.0"
-]
-requires-python = ">= 3.10"
+dependencies = [ "mirakuru>=2.6.0", "packaging", "port-for>=0.7.3", "psycopg>=3.0.0", "pytest>=8.2" ]
 
-[project.optional-dependencies]
-async = [
-  "pytest-asyncio >= 1.4",
-  "aiofiles >= 23.0"
-]
+[[project.authors]]
+name = "Grzegorz Śliwiński"
+email = "fizyk+pypi@fizyk.dev"
 
-[project.urls]
-"Source" = "https://github.com/dbfixtures/pytest-postgresql"
-"Bug Tracker" = "https://github.com/dbfixtures/pytest-postgresql/issues"
-"Changelog" = "https://github.com/dbfixtures/pytest-postgresql/blob/v8.1.0/CHANGES.rst"
-
-[project.entry-points."pytest11"]
+[project.entry-points.pytest11]
 pytest_postgresql = "pytest_postgresql.plugin"
 
-[build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+[project.optional-dependencies]
+async = [ "aiofiles>=23.0", "pytest-asyncio>=1.4" ]
+
+[project.urls]
+Source = "https://github.com/dbfixtures/pytest-postgresql"
+"Bug Tracker" = "https://github.com/dbfixtures/pytest-postgresql/issues"
+Changelog = "https://github.com/dbfixtures/pytest-postgresql/blob/v8.1.0/CHANGES.rst"
 
 [tool.setuptools]
 zip-safe = true
 
 [tool.setuptools.packages.find]
-include = ["pytest_postgresql*"]
-exclude = ["tests*"]
+include = [ "pytest_postgresql*" ]
+exclude = [ "tests*" ]
 namespaces = false
 
-[tool.pytest]
-strict_xfail=true
-addopts = ["--showlocals", "--verbose"]
-testpaths = ["tests"]
-pytester_example_dir = "tests/examples"
-norecursedirs = ["examples"]
-
 [tool.ruff]
+target-version = "py310"
 line-length = 120
-target-version = 'py310'
 
 [tool.ruff.lint]
 select = [
-  "E",   # pycodestyle
-  "F",   # pyflakes
-  "I",   # isort
-  "D",   # pydocstyle
+    "E", # pycodestyle
+    "F", # pyflakes
+    "I", # isort
+    "D", # pydocstyle
 ]
 
-[tool.rstcheck]
-report_level = "warning"
+[tool.pyproject-fmt]
+column_width = 120
+indent = 4
+keep_full_version = true
+generate_python_version_classifiers = false
+table_format = "long"
+sub_table_spacing = "\n"
 
 [tool.mypy]
-allow_redefinition = "False"
-allow_untyped_globals = "False"
-check_untyped_defs = "True"
-disallow_incomplete_defs = "True"
-disallow_subclassing_any = "True"
-disallow_untyped_calls = "True"
-disallow_untyped_decorators = "True"
-disallow_untyped_defs = "True"
+ignore_missing_imports = false
 follow_imports = "silent"
-ignore_missing_imports = "False"
-implicit_reexport = "False"
-no_implicit_optional = "True"
-pretty = "True"
-show_error_codes = "True"
-strict_equality = "True"
-warn_no_return = "True"
-warn_return_any = "True"
-warn_unreachable = "True"
-warn_unused_ignores = "True"
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+allow_untyped_globals = false
+allow_redefinition = false
+implicit_reexport = false
+strict_equality = true
+pretty = true
+no_implicit_optional = true
+show_error_codes = true
+
+[tool.pytest]
+addopts = [ "--showlocals", "--verbose" ]
+norecursedirs = [ "examples" ]
+pytester_example_dir = "tests/examples"
+strict_xfail = true
+testpaths = [ "tests" ]
+
+[[tool.tbump.before_commit]]
+name = "Build changelog"
+cmd = "pipenv run towncrier build --version {new_version} --yes"
+
+[[tool.tbump.field]]
+name = "extra"
+default = ""
+
+[[tool.tbump.file]]
+src = "pytest_postgresql/__init__.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'Changelog = "https://github.com/dbfixtures/pytest-postgresql/blob/v{current_version}/CHANGES.rst"'
+
+[tool.tbump.git]
+message_template = "Release {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "8.1.0"
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<extra>.+)
+  )?
+  '''
 
 [tool.towncrier]
 directory = "newsfragments"
-single_file=true
-filename="CHANGES.rst"
-issue_format="`#{issue} <https://github.com/dbfixtures/pytest-postgresql/issues/{issue}>`__"
+filename = "CHANGES.rst"
+issue_format = "`#{issue} <https://github.com/dbfixtures/pytest-postgresql/issues/{issue}>`__"
+single_file = true
 
 [[tool.towncrier.type]]
 directory = "break"
@@ -141,57 +174,5 @@ directory = "misc"
 name = "Miscellaneous"
 showcontent = true
 
-[tool.tbump.version]
-current = "8.1.0"
-
-# Example of a semver regexp.
-# Make sure this matches current_version before
-# using tbump
-regex = '''
-  (?P<major>\d+)
-  \.
-  (?P<minor>\d+)
-  \.
-  (?P<patch>\d+)
-  (\-
-    (?P<extra>.+)
-  )?
-  '''
-
-[tool.tbump.git]
-message_template = "Release {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.field]]
-# the name of the field
-name = "extra"
-# the default value to use, if there is no match
-default = ""
-# For each file to patch, add a [[file]] config
-# section containing the path of the file, relative to the
-# tbump.toml location.
-
-[[tool.tbump.file]]
-src = "pytest_postgresql/__init__.py"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = 'version = "{current_version}"'
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = '"Changelog" = "https://github.com/dbfixtures/pytest-postgresql/blob/v{current_version}/CHANGES.rst"'
-
-# You can specify a list of commands to
-# run after the files have been patched
-# and before the git commit is made
-
-[[tool.tbump.before_commit]]
-name = "Build changelog"
-cmd = "pipenv run towncrier build --version {new_version} --yes"
-
-# Or run some commands after the git tag and the branch
-# have been pushed:
-#  [[tool.tbump.after_push]]
-#  name = "publish"
-#  cmd = "./publish.sh"
+[tool.rstcheck]
+report_level = "warning"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automatic `pyproject.toml` formatting to the pre-commit checks using `pyproject-fmt` (pinned version).
  * Standardised and reformatted project metadata, build settings, and development tooling configuration in `pyproject.toml`.
  * Updated the changelog/news fragment to reflect the new formatting check and related configuration normalisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->