### PR TITLE
Pin GitHub Actions to immutable commit SHAs - closes #1331

### DIFF
--- a/.github/workflows/async-postgres.yml
+++ b/.github/workflows/async-postgres.yml
@@ -30,7 +30,7 @@ jobs:
       PYTHON: ${{ inputs.python-version }}
       POSTGRES: ${{ inputs.postgresql }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Set up Python ${{ inputs.python-version }}
@@ -69,7 +69,7 @@ jobs:
         uses: fizyk/actions-reuse/.github/actions/uv-run@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
           command: python -m pytest -svv -m asyncio -p no:xdist --postgresql-exec="${{ env.POSTGRESQL_EXEC }}" -k "not docker" --basetemp="${{ runner.temp }}/pytest-basetemp"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: postgresql-async-${{ inputs.python-version }}-${{ inputs.postgresql }}-${{ inputs.os }}

--- a/.github/workflows/dockerised-postgres.yml
+++ b/.github/workflows/dockerised-postgres.yml
@@ -49,7 +49,9 @@ jobs:
           - 5433:5432
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Pipenv on python ${{ matrix.python-version }}
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
@@ -68,7 +70,7 @@ jobs:
           output-file: coverage-docker.xml
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.1
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests

--- a/.github/workflows/oldest-postgres.yml
+++ b/.github/workflows/oldest-postgres.yml
@@ -35,7 +35,9 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       POSTGRES: ${{ inputs.postgresql }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Pipenv on python ${{ matrix.python-version }}
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
@@ -82,14 +84,14 @@ jobs:
         with:
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: postgresql-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: ${{ runner.temp }}/pytest-basetemp/**
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.1
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,11 +18,11 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions 📦
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true

--- a/.github/workflows/single-postgres-windows.yml
+++ b/.github/workflows/single-postgres-windows.yml
@@ -30,7 +30,9 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       POSTGRES: ${{ inputs.postgresql }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Pipenv on python ${{ matrix.python-version }}
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
@@ -65,14 +67,14 @@ jobs:
         with:
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: postgresql-windows-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: ${{ runner.temp }}/pytest-basetemp/**
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.1
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests

--- a/.github/workflows/single-postgres.yml
+++ b/.github/workflows/single-postgres.yml
@@ -35,7 +35,9 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       POSTGRES: ${{ inputs.postgresql }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Pipenv on python ${{ matrix.python-version }}
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
@@ -96,14 +98,14 @@ jobs:
         with:
           data-file: .coverage.xdist
           output-file: coverage-xdist.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: postgresql-${{ matrix.python-version }}-${{ inputs.postgresql }}
           path: ${{ runner.temp }}/pytest-basetemp/**
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.1
         with:
           token: ${{ secrets.codecov_token }}
           flags: unittests

--- a/newsfragments/1331.misc.rst
+++ b/newsfragments/1331.misc.rst
@@ -1,0 +1,1 @@
+Pin GitHub Actions to immutable commit SHAs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - GitHub Actions workflows now use immutable commit references for checkout, artifact uploads, coverage reporting, package publishing, and artifact downloads.
  - Existing testing, coverage, publishing, and failure-reporting behaviour remains unchanged.

- **Documentation**
  - Added a release note documenting the policy of pinning GitHub Actions to immutable revisions for improved workflow consistency and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->