### PR TITLE
Fix flake in test_postgres_terminate_connection

### DIFF
--- a/newsfragments/+deflake-terminate-connection.misc.rst
+++ b/newsfragments/+deflake-terminate-connection.misc.rst
@@ -1,0 +1,5 @@
+Scope the ``test_postgres_terminate_connection`` (and async) connection check
+to the test's own database via ``datname = current_database()``.
+
+So a transient, already-closed janitor connection on the ``postgres`` maintenance
+database no longer causes spurious timeouts on macOS CI.

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -63,7 +63,9 @@ def test_postgres_terminate_connection(postgresql2: Connection, _: int) -> None:
     with postgresql2.cursor() as cur:
 
         def check_if_one_connection() -> None:
-            cur.execute("SELECT * FROM pg_stat_activity WHERE backend_type = 'client backend';")
+            cur.execute(
+                "SELECT * FROM pg_stat_activity WHERE backend_type = 'client backend' AND datname = current_database();"
+            )
             existing_connections = cur.fetchall()
             assert len(existing_connections) == 1, f"there is always only one connection, {existing_connections}"
 
@@ -120,7 +122,9 @@ async def test_postgres_terminate_connection_async(postgresql2_async: AsyncConne
     async with postgresql2_async.cursor() as cur:
 
         async def check_if_one_connection() -> None:
-            await cur.execute("SELECT * FROM pg_stat_activity WHERE backend_type = 'client backend';")
+            await cur.execute(
+                "SELECT * FROM pg_stat_activity WHERE backend_type = 'client backend' AND datname = current_database();"
+            )
             existing_connections = await cur.fetchall()
             assert len(existing_connections) == 1, f"there is always only one connection, {existing_connections}"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-termination verification for both synchronous and asynchronous tests.
  * Updated the activity checks to restrict results to the active database, avoiding intermittent timeout failures caused by unrelated maintenance connections on some CI environments (e.g., macOS).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->