### PR TITLE
Add zizmor to pre-commit

### DIFF
--- a/.github/actions/detect-pg-ctl/action.yml
+++ b/.github/actions/detect-pg-ctl/action.yml
@@ -8,9 +8,11 @@ runs:
   using: composite
   steps:
     - shell: pwsh
-      run: |
+      env:
+        POSTGRESQL_VERSION: ${{ inputs.postgresql-version }}
+      run: | # zizmor: ignore[github-env]
         $pgFound = $false
-        $hardcodedPath = "C:\Program Files\PostgreSQL\${{ inputs.postgresql-version }}\bin\pg_ctl.exe"
+        $hardcodedPath = "C:\Program Files\PostgreSQL\$env:POSTGRESQL_VERSION\bin\pg_ctl.exe"
         if (Test-Path $hardcodedPath) {
           echo "POSTGRESQL_EXEC=$hardcodedPath" >> $env:GITHUB_ENV
           $pgFound = $true

--- a/.github/workflows/async-postgres.yml
+++ b/.github/workflows/async-postgres.yml
@@ -37,7 +37,10 @@ jobs:
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
           python-version: ${{ inputs.python-version }}
-      - uses: ankane/setup-postgres@v1
+      # ankane/setup-postgres publishes no tags/releases; v1 is a branch. Pinning
+      # to a SHA gains nothing (Dependabot can't track a branch). Revisit if the
+      # maintainer adds releases. See https://docs.zizmor.sh/audits/#unpinned-uses
+      - uses: ankane/setup-postgres@v1 # zizmor: ignore[unpinned-uses]
         with:
           postgres-version: ${{ inputs.postgresql }}
       - name: Set PostgreSQL path on Linux

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,6 @@
 name: Merge me test dependencies!
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     types:
       - completed
@@ -12,6 +12,8 @@ on:
   check_suite:
     types:
       - completed
+
+permissions: {}
 
 jobs:
   automerge:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,14 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
+
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: read  # actions/checkout in the reusable workflow
     uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
     with:
       dependency-manager: uv

--- a/.github/workflows/oldest-postgres.yml
+++ b/.github/workflows/oldest-postgres.yml
@@ -43,7 +43,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: false
-      - uses: ankane/setup-postgres@v1
+      # ankane/setup-postgres publishes no tags/releases; v1 is a branch. Pinning
+      # to a SHA gains nothing (Dependabot can't track a branch). Revisit if the
+      # maintainer adds releases. See https://docs.zizmor.sh/audits/#unpinned-uses
+      - uses: ankane/setup-postgres@v1 # zizmor: ignore[unpinned-uses]
         with:
           postgres-version: ${{ inputs.postgresql }}
       - name: Check installed locales

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   pr-check:
+    permissions:
+      contents: read
     uses: fizyk/actions-reuse/.github/workflows/shared-pr-check.yml@5e3ff7b4d544d6b3b8336cdc9c029cff9ab7abb3 # v5.2.7
     with:
       dependency-manager: 'uv'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
 
 
+permissions: {}
+
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     uses: fizyk/actions-reuse/.github/workflows/shared-pre-commit.yml@5e3ff7b4d544d6b3b8336cdc9c029cff9ab7abb3 # v5.2.7

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,11 +3,13 @@ on:
   push:
     tags:
       - v*
+permissions: {}
+
 jobs:
   build:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@v4.4.7
-    with:
-      publish: false
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build.yml
 
   publish:
     name: Publish Python 🐍 distributions 📦 to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   release:
     uses: fizyk/actions-reuse/.github/workflows/shared-release.yml@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6

--- a/.github/workflows/single-postgres-windows.yml
+++ b/.github/workflows/single-postgres-windows.yml
@@ -37,7 +37,10 @@ jobs:
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: ankane/setup-postgres@v1
+      # ankane/setup-postgres publishes no tags/releases; v1 is a branch. Pinning
+      # to a SHA gains nothing (Dependabot can't track a branch). Revisit if the
+      # maintainer adds releases. See https://docs.zizmor.sh/audits/#unpinned-uses
+      - uses: ankane/setup-postgres@v1 # zizmor: ignore[unpinned-uses]
         with:
           postgres-version: ${{ inputs.postgresql }}
       - uses: ./.github/actions/detect-pg-ctl

--- a/.github/workflows/single-postgres.yml
+++ b/.github/workflows/single-postgres.yml
@@ -42,7 +42,10 @@ jobs:
         uses: fizyk/actions-reuse/.github/actions/uv-setup@e434952f57d1da48b52d0fe5454b365b2f297d2d # v5.2.6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: ankane/setup-postgres@v1
+      # ankane/setup-postgres publishes no tags/releases; v1 is a branch. Pinning
+      # to a SHA gains nothing (Dependabot can't track a branch). Revisit if the
+      # maintainer adds releases. See https://docs.zizmor.sh/audits/#unpinned-uses
+      - uses: ankane/setup-postgres@v1 # zizmor: ignore[unpinned-uses]
         with:
           postgres-version: ${{ inputs.postgresql }}
       - name: Set PostgreSQL path

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --respect-gitignore, --show-fixes]
       - id: ruff-format
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.25.3
     hooks:

--- a/newsfragments/+zizmor.misc.rst
+++ b/newsfragments/+zizmor.misc.rst
@@ -1,0 +1,1 @@
+Add zizmor to pre-commit and harden GitHub Actions workflow permissions.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened GitHub Actions default token permissions to an empty baseline, with jobs granting only the minimum required access.
  * Documented and safeguarded PostgreSQL setup workflow usage where unpinned references are intentionally tolerated.
* **Automation**
  * Made the build workflow callable as a reusable workflow for other pipelines.
  * Updated publishing-related automation to rely on the repository’s standard build workflow.
* **Quality**
  * Improved Windows PostgreSQL control detection used in CI runs.
  * Added Zizmor to pre-commit checks for automated workflow security validation.
* **Documentation**
  * Added a release/news fragment describing the workflow permission hardening and validation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->