### PR TITLE
Set CodeRabbit review profile to assertive

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,6 @@
 language: en-GB
 reviews:
+  profile: assertive
   path_instructions:
     - path: "newsfragments/*.rst"
       instructions: |

--- a/newsfragments/+coderabbit-assertive.misc.rst
+++ b/newsfragments/+coderabbit-assertive.misc.rst
@@ -1,0 +1,1 @@
+Set CodeRabbit review profile to assertive for stricter pull request reviews.


### PR DESCRIPTION
## Summary
- Set `reviews.profile` to `assertive` in `.coderabbit.yaml` so CodeRabbit uses stricter, more comprehensive PR reviews (docs default is `chill`).
- Leaves existing newsfragment path instructions and pre-merge checks unchanged; auto-review remains on via CodeRabbit defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review configuration to use a more assertive review profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->